### PR TITLE
Add cluster admin access and web UI docs to Getting Started guides

### DIFF
--- a/orka/orka-on-aws-and-on-prem/orka-on-aws-getting-started.mdx
+++ b/orka/orka-on-aws-and-on-prem/orka-on-aws-getting-started.mdx
@@ -207,7 +207,7 @@ We recommend using the [AWS Load Balancer Controller](https://kubernetes-sigs.gi
 
 ### Cluster Admin Access
 
-By default, Orka's validator webhooks restrict certain operations — including deleting another user's VM — to cluster admins only. On AWS and on-prem deployments, cluster admin status must be explicitly configured. This differs from MacStadium-hosted clusters, where kubeadm automatically establishes the `kubeadm:cluster-admins` group.
+By default, Orka's validator webhooks restrict certain operations (including deleting another user's VM) to cluster admins only. On AWS and on-prem deployments, cluster admin status must be explicitly configured. This differs from MacStadium-hosted clusters, where kubeadm automatically establishes the `kubeadm:cluster-admins` group.
 
 The default admin group for AWS and on-prem is `orka:cluster-admins`. To use a different group, set the `cluster_admin_group` Ansible variable before running the installation playbook.
 
@@ -215,7 +215,7 @@ To grant a user cluster admin access, add them to the `orka:cluster-admins` grou
 
 ### Web UI
 
-The Orka Web UI is not actively maintained and is not recommended for production use. If you need to access it, you can expose the web UI service using an ingress controller or load balancer — see [Exposing the Orka API Service](#exposing-the-orka-api-service) for the approach.
+The Orka Web UI is not actively maintained and is not recommended for production use. If you need to access it, you can expose the web UI service using an ingress controller or load balancer; see [Exposing the Orka API Service](#exposing-the-orka-api-service) for the approach.
 
 ## EC2 Mac Install Steps
 

--- a/orka/orka-on-aws-and-on-prem/orka-on-prem-getting-started.mdx
+++ b/orka/orka-on-aws-and-on-prem/orka-on-prem-getting-started.mdx
@@ -187,7 +187,7 @@ One way to expose the service is to use something like [MetalLB](https://metallb
 
 ### Cluster Admin Access
 
-By default, Orka's validator webhooks restrict certain operations — including deleting another user's VM — to cluster admins only. On AWS and on-prem deployments, cluster admin status must be explicitly configured. This differs from MacStadium-hosted clusters, where kubeadm automatically establishes the `kubeadm:cluster-admins` group.
+By default, Orka's validator webhooks restrict certain operations (including deleting another user's VM) to cluster admins only. On AWS and on-prem deployments, cluster admin status must be explicitly configured. This differs from MacStadium-hosted clusters, where kubeadm automatically establishes the `kubeadm:cluster-admins` group.
 
 The default admin group for AWS and on-prem is `orka:cluster-admins`. To use a different group, set the `cluster_admin_group` Ansible variable before running the installation playbook.
 
@@ -195,7 +195,7 @@ To grant a user cluster admin access, add them to the `orka:cluster-admins` grou
 
 ### Web UI
 
-The Orka Web UI is not actively maintained and is not recommended for production use. If you need to access it, you can expose the web UI service using an ingress controller or load balancer — see [Exposing the Orka API Service](#exposing-the-orka-api-service) for the approach.
+The Orka Web UI is not actively maintained and is not recommended for production use. If you need to access it, you can expose the web UI service using an ingress controller or load balancer; see [Exposing the Orka API Service](#exposing-the-orka-api-service) for the approach.
 
 ## Setting Up Mac Nodes[](https://orkadocs.macstadium.com/docs/orka-cluster-32-on-prem-getting-started#setting-up-mac-nodes)
 


### PR DESCRIPTION
## Summary

Addresses documentation gaps flagged by Spike Burton following SentinelOne and Epic customer feedback.

- **Cluster admin access:** Documents the `orka:cluster-admins` RBAC group that bypasses validator webhooks for admin operations (e.g. deleting another user's VM). Notes the `cluster_admin_group` Ansible variable for customizing the group.
- **Web UI:** Adds a note that the web UI is not actively maintained and not recommended, with guidance on how to expose it via ingress/loadbalancer if needed.

Both sections added to Orka on AWS Getting Started and Orka On-Prem Getting Started.

**Note on Swagger / Bearer token:** Spike also flagged that the Bearer token requirement isn't obvious in Swagger. This is already documented in the [Orka3 API Quick Start](../orka/quick-start-guides/orka3-api-quick-start.mdx) (line 107 specifically addresses Swagger). No change needed there — just a discoverability issue worth noting to Spike.

## Test plan

- [x] Review wording on both articles
- [x] Merge and verify pages render correctly in Mintlify

🤖 Generated with [Claude Code](https://claude.com/claude-code)