### PR TITLE
Add required theme field to docs.json

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1,4 +1,5 @@
 {
+  "theme": "mint",
   "name": "MacStadium Docs",
   "logo": {
     "light": "/logo/light.svg",


### PR DESCRIPTION
## Summary

- Adds `"theme": "mint"` to `docs.json`

The new `docs.json` schema requires a `theme` value. Without it, Mintlify throws: `Invalid docs.json: #.theme: Invalid discriminator value`. Using `mint` (the classic default, equivalent to the previous behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)