### PR TITLE
Fix Suggest Edits URL to point to renamed repo

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1500,7 +1500,7 @@
   ],
   "contribution": {
     "suggestEdit": {
-      "url": "https://github.com/macstadium/macstadium-docs-trial/edit/main/",
+      "url": "https://github.com/macstadium/macstadium-docs/edit/main/",
       "label": "Suggest Edits"
     }
   },


### PR DESCRIPTION
The repo was renamed from `macstadium-docs-trial` to `macstadium-docs` but the Suggest Edits button URL wasn't updated. Fixes the edit link on every article page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)