### PR TITLE
Fix MDX parse errors: replace HTML comments with JSX comments

### DIFF
--- a/iaas/iaas-faqs/can-a-hosted-mac-server-offer-a-virtual-desktop-at-4k-resolution.mdx
+++ b/iaas/iaas-faqs/can-a-hosted-mac-server-offer-a-virtual-desktop-at-4k-resolution.mdx
@@ -12,7 +12,7 @@ labels: ["mac", "faq", "server", "virtual", "4k", "desktop"]
 suggested_new_path: "/iaas/iaas-faqs/can-a-hosted-mac-server-offer-a-virtual-desktop-at-4k-resolution"
 ---
 
-<!-- schema:injected -->
+{/* schema:injected */}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/iaas/iaas-faqs/can-i-change-the-os-on-my-server-from-macos-to-linux.mdx
+++ b/iaas/iaas-faqs/can-i-change-the-os-on-my-server-from-macos-to-linux.mdx
@@ -12,7 +12,7 @@ labels: ["mini", "mac", "faq", "macos", "linux", "server"]
 suggested_new_path: "/iaas/iaas-faqs/can-i-change-the-os-on-my-server-from-macos-to-linux"
 ---
 
-<!-- schema:injected -->
+{/* schema:injected */}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/iaas/iaas-faqs/do-i-have-root-and-admin-access-to-subscription-based-mac-servers.mdx
+++ b/iaas/iaas-faqs/do-i-have-root-and-admin-access-to-subscription-based-mac-servers.mdx
@@ -12,7 +12,7 @@ labels: ["subscription", "faq", "server", "access", "root", "admin", "servers"]
 suggested_new_path: "/iaas/iaas-faqs/do-i-have-root-and-admin-access-to-subscription-based-mac-servers"
 ---
 
-<!-- schema:injected -->
+{/* schema:injected */}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/iaas/iaas-faqs/do-i-need-a-vnc-server-installed-on-my-mac.mdx
+++ b/iaas/iaas-faqs/do-i-need-a-vnc-server-installed-on-my-mac.mdx
@@ -12,7 +12,7 @@ labels: ["mini", "mac", "faq", "server", "vnc"]
 suggested_new_path: "/iaas/iaas-faqs/do-i-need-a-vnc-server-installed-on-my-mac"
 ---
 
-<!-- schema:injected -->
+{/* schema:injected */}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/iaas/iaas-faqs/how-do-i-order-multiple-servers-at-one-time.mdx
+++ b/iaas/iaas-faqs/how-do-i-order-multiple-servers-at-one-time.mdx
@@ -12,7 +12,7 @@ labels: ["faq", "servers", "multiple"]
 suggested_new_path: "/iaas/iaas-faqs/how-do-i-order-multiple-servers-at-one-time"
 ---
 
-<!-- schema:injected -->
+{/* schema:injected */}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/iaas/iaas-faqs/is-there-macos-software-to-replace-the-popular-web-hosting-software-offered-by-l.mdx
+++ b/iaas/iaas-faqs/is-there-macos-software-to-replace-the-popular-web-hosting-software-offered-by-l.mdx
@@ -12,7 +12,7 @@ labels: ["host", "faq", "linux", "macOS", "hosting", "vps"]
 suggested_new_path: "/iaas/iaas-faqs/is-there-macos-software-to-replace-the-popular-web-hosting-software-offered-by-l"
 ---
 
-<!-- schema:injected -->
+{/* schema:injected */}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/iaas/iaas-faqs/what-are-macstadiums-proprietary-mac-pro-upgrades.mdx
+++ b/iaas/iaas-faqs/what-are-macstadiums-proprietary-mac-pro-upgrades.mdx
@@ -12,7 +12,7 @@ labels: ["hardware", "mac", "faq", "pro", "upgrade", "upgrades", "mac pro"]
 suggested_new_path: "/iaas/iaas-faqs/what-are-macstadiums-proprietary-mac-pro-upgrades"
 ---
 
-<!-- schema:injected -->
+{/* schema:injected */}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/iaas/iaas-faqs/what-do-i-do-if-i-accidentally-turned-off-vnc-on-my-hosted-mac.mdx
+++ b/iaas/iaas-faqs/what-do-i-do-if-i-accidentally-turned-off-vnc-on-my-hosted-mac.mdx
@@ -12,7 +12,7 @@ labels: ["hardware", "faq", "vnc", "off"]
 suggested_new_path: "/iaas/iaas-faqs/what-do-i-do-if-i-accidentally-turned-off-vnc-on-my-hosted-mac"
 ---
 
-<!-- schema:injected -->
+{/* schema:injected */}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/iaas/iaas-faqs/what-is-instant-provisioning-and-how-long-does-it-take.mdx
+++ b/iaas/iaas-faqs/what-is-instant-provisioning-and-how-long-does-it-take.mdx
@@ -12,7 +12,7 @@ labels: ["faq", "provision", "provisioning", "instant"]
 suggested_new_path: "/iaas/iaas-faqs/what-is-instant-provisioning-and-how-long-does-it-take"
 ---
 
-<!-- schema:injected -->
+{/* schema:injected */}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/iaas/iaas-faqs/whats-the-ola-on-rebooting-a-dedicated-mac-host.mdx
+++ b/iaas/iaas-faqs/whats-the-ola-on-rebooting-a-dedicated-mac-host.mdx
@@ -12,7 +12,7 @@ labels: ["hardware", "host", "mac", "faq", "ola", "reboot", "rebooting"]
 suggested_new_path: "/iaas/iaas-faqs/whats-the-ola-on-rebooting-a-dedicated-mac-host"
 ---
 
-<!-- schema:injected -->
+{/* schema:injected */}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/iaas/iaas-faqs/why-are-coreaudiod-and-launchd-using-a-high-amount-of-resources.mdx
+++ b/iaas/iaas-faqs/why-are-coreaudiod-and-launchd-using-a-high-amount-of-resources.mdx
@@ -12,7 +12,7 @@ labels: ["faq", "coreaudiod", "resources"]
 suggested_new_path: "/iaas/iaas-faqs/why-are-coreaudiod-and-launchd-using-a-high-amount-of-resources"
 ---
 
-<!-- schema:injected -->
+{/* schema:injected */}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/macstadium/account-management-and-saml/enable-saml-sso-with-azure-active-directory.mdx
+++ b/macstadium/account-management-and-saml/enable-saml-sso-with-azure-active-directory.mdx
@@ -12,7 +12,7 @@ labels: ["sso", "saml", "azure", "active directory"]
 suggested_new_path: "/macstadium/account-management-and-saml/enable-saml-sso-with-azure-active-directory"
 ---
 
-<!-- schema:injected -->
+{/* schema:injected */}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/macstadium/account-management-and-saml/enable-saml-sso-with-google-workspace-federation.mdx
+++ b/macstadium/account-management-and-saml/enable-saml-sso-with-google-workspace-federation.mdx
@@ -12,7 +12,7 @@ labels: ["federation", "sso", "google", "saml", "workspace"]
 suggested_new_path: "/macstadium/account-management-and-saml/enable-saml-sso-with-google-workspace-federation"
 ---
 
-<!-- schema:injected -->
+{/* schema:injected */}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/remote-desktop-vdi/cloud-access-legacy/connect-to-your-cloud-ssh.mdx
+++ b/remote-desktop-vdi/cloud-access-legacy/connect-to-your-cloud-ssh.mdx
@@ -16,7 +16,7 @@ suggested_new_path: "/remote-desktop-vdi/cloud-access-legacy/connect-to-your-clo
   **Cloud Access is no longer sold directly by MacStadium.** Renewals are supported, but new customers should purchase [HP Anyware](https://anyware.hp.com/) directly. This documentation is preserved for existing customers. For remote macOS access, see [Orka for VDI](/remote-desktop-vdi/orka-for-vdi-deployment/overview-architecture). Questions? Contact [support@macstadium.com](mailto:support@macstadium.com).
 </Warning>
 
-<!-- schema:injected -->
+{/* schema:injected */}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/remote-desktop-vdi/cloud-access-legacy/connect-to-your-cloud-via-vpn.mdx
+++ b/remote-desktop-vdi/cloud-access-legacy/connect-to-your-cloud-via-vpn.mdx
@@ -16,7 +16,7 @@ suggested_new_path: "/remote-desktop-vdi/cloud-access-legacy/connect-to-your-clo
   **Cloud Access is no longer sold directly by MacStadium.** Renewals are supported, but new customers should purchase [HP Anyware](https://anyware.hp.com/) directly. This documentation is preserved for existing customers. For remote macOS access, see [Orka for VDI](/remote-desktop-vdi/orka-for-vdi-deployment/overview-architecture). Questions? Contact [support@macstadium.com](mailto:support@macstadium.com).
 </Warning>
 
-<!-- schema:injected -->
+{/* schema:injected */}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/remote-desktop-vdi/cloud-access-legacy/connect-to-your-cloud-windows.mdx
+++ b/remote-desktop-vdi/cloud-access-legacy/connect-to-your-cloud-windows.mdx
@@ -16,7 +16,7 @@ suggested_new_path: "/remote-desktop-vdi/cloud-access-legacy/connect-to-your-clo
   **Cloud Access is no longer sold directly by MacStadium.** Renewals are supported, but new customers should purchase [HP Anyware](https://anyware.hp.com/) directly. This documentation is preserved for existing customers. For remote macOS access, see [Orka for VDI](/remote-desktop-vdi/orka-for-vdi-deployment/overview-architecture). Questions? Contact [support@macstadium.com](mailto:support@macstadium.com).
 </Warning>
 
-<!-- schema:injected -->
+{/* schema:injected */}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",


### PR DESCRIPTION
## Summary

- `inject-schema-markup.py` left `<!-- schema:injected -->` markers in 16 files
- HTML comments (`<!--`) are invalid MDX syntax — the parser throws `Unexpected character ! (U+0021) before name`
- Replaces all occurrences with `{/* schema:injected */}` across all 16 affected files

## Files fixed

3 were actively failing deployment (touched in PR #16), 13 more preemptively fixed before they caused future failures:

- `remote-desktop-vdi/cloud-access-legacy/connect-to-your-cloud-ssh.mdx` ← was failing
- `remote-desktop-vdi/cloud-access-legacy/connect-to-your-cloud-via-vpn.mdx` ← was failing
- `remote-desktop-vdi/cloud-access-legacy/connect-to-your-cloud-windows.mdx` ← was failing
- 13 × `iaas/iaas-faqs/*.mdx` and `macstadium/account-management-and-saml/*.mdx`

## Test plan

- [x] Mintlify deployment check passes on this PR
- [ ] No `<!--` in any `.mdx` file (`grep -rn "<!--" --include="*.mdx" .` returns empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)