### PR TITLE
Remove invalid JSON-LD script blocks from MDX files

### DIFF
--- a/iaas/iaas-faqs/can-a-hosted-mac-server-offer-a-virtual-desktop-at-4k-resolution.mdx
+++ b/iaas/iaas-faqs/can-a-hosted-mac-server-offer-a-virtual-desktop-at-4k-resolution.mdx
@@ -12,23 +12,6 @@ labels: ["mac", "faq", "server", "virtual", "4k", "desktop"]
 suggested_new_path: "/iaas/iaas-faqs/can-a-hosted-mac-server-offer-a-virtual-desktop-at-4k-resolution"
 ---
 
-{/* schema:injected */}
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "Can a hosted Mac server offer a virtual desktop at 4k resolution?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "After some minor upgrades, a hosted Mac can make a great virtual desktop interface. By connecting a GPU enabler to the unused HDMI port, we can make the Mac believe it's connected to a display. This simple addition causes the Mac server to then enable GPU acceleration by emulating a display. New, high-definition display resolutions are then available for users connecting via screen sharing, VNC, or remote desktop. By default, we include a fit-Headless GPU enabler on every new dedicated server. T"
-      }
-    }
-  ]
-}
-</script>
 
 After some minor upgrades, a hosted Mac can make a great virtual desktop interface. By connecting a GPU enabler to the unused HDMI port, we can make the Mac believe it's connected to a display. This simple addition causes the Mac server to then enable GPU acceleration by emulating a display. New, high-definition display resolutions are then available for users connecting via screen sharing, VNC, or remote desktop.
 

--- a/iaas/iaas-faqs/can-i-change-the-os-on-my-server-from-macos-to-linux.mdx
+++ b/iaas/iaas-faqs/can-i-change-the-os-on-my-server-from-macos-to-linux.mdx
@@ -12,22 +12,5 @@ labels: ["mini", "mac", "faq", "macos", "linux", "server"]
 suggested_new_path: "/iaas/iaas-faqs/can-i-change-the-os-on-my-server-from-macos-to-linux"
 ---
 
-{/* schema:injected */}
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "Can I change the OS on my server from macOS to Linux?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "MacStadium recommends our Private Cloud x86 VMs for Linux or Windows OS."
-      }
-    }
-  ]
-}
-</script>
 
 MacStadium recommends our Private Cloud x86 VMs for Linux or Windows OS.

--- a/iaas/iaas-faqs/do-i-have-root-and-admin-access-to-subscription-based-mac-servers.mdx
+++ b/iaas/iaas-faqs/do-i-have-root-and-admin-access-to-subscription-based-mac-servers.mdx
@@ -12,23 +12,6 @@ labels: ["subscription", "faq", "server", "access", "root", "admin", "servers"]
 suggested_new_path: "/iaas/iaas-faqs/do-i-have-root-and-admin-access-to-subscription-based-mac-servers"
 ---
 
-{/* schema:injected */}
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "Do I have root and admin access to subscription-based Mac servers?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "For every subscription to a hosted Mac running macOS, we provide an administrator account and the ability to modify system-level files. Login as administrator to a Mac running macOS and you have complete control over the system. SSH and VNC access are enabled by default on dedicated servers so you can access them from any device. It's no different than if the server were on your local network. We do require that you follow the guidelines set in our Terms of Service and Acceptable Use Policy whic"
-      }
-    }
-  ]
-}
-</script>
 
 For every subscription to a hosted Mac running macOS, we provide an administrator account and the ability to modify system-level files. Login as administrator to a Mac running macOS and you have complete control over the system.
 

--- a/iaas/iaas-faqs/do-i-need-a-vnc-server-installed-on-my-mac.mdx
+++ b/iaas/iaas-faqs/do-i-need-a-vnc-server-installed-on-my-mac.mdx
@@ -12,23 +12,6 @@ labels: ["mini", "mac", "faq", "server", "vnc"]
 suggested_new_path: "/iaas/iaas-faqs/do-i-need-a-vnc-server-installed-on-my-mac"
 ---
 
-{/* schema:injected */}
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "Do I need a VNC server installed on my Mac?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "One of the more popular free VNC tools used by our clients, RealVNC, now offers their server product under the name VNC Connect. Customers often ask us whether they need VNC Connect on their Mac running macOS. Apple\u2019s macOS also includes a built-in default VNC server. We enable this for every hosted Mac running any version of macOS before releasing the server to a customer. To connect to one of our Mac servers running macOS, you need a VNC client like the one RealVNC offers, VNC Viewer. VNC Conn"
-      }
-    }
-  ]
-}
-</script>
 
 One of the more popular free VNC tools used by our clients, RealVNC, now offers their server product under the name VNC Connect. Customers often ask us whether they need VNC Connect on their Mac running macOS.
 

--- a/iaas/iaas-faqs/how-do-i-order-multiple-servers-at-one-time.mdx
+++ b/iaas/iaas-faqs/how-do-i-order-multiple-servers-at-one-time.mdx
@@ -12,23 +12,6 @@ labels: ["faq", "servers", "multiple"]
 suggested_new_path: "/iaas/iaas-faqs/how-do-i-order-multiple-servers-at-one-time"
 ---
 
-{/* schema:injected */}
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "How do I order multiple servers at one time?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "If you are registering and have an immediate need for five or more machines, you will first need to verify your billing information before you can order them. After your registration is complete, you can either complete a single subscription or head into your customer dashboard to add additional machines to your account. If you would rather get five or more machines at once and you can provide the technical specifications for each Mac (or you need something not shown in the configuration wizard)"
-      }
-    }
-  ]
-}
-</script>
 
 If you are registering and have an immediate need for five or more machines, you will first need to verify your billing information before you can order them.
 

--- a/iaas/iaas-faqs/is-there-macos-software-to-replace-the-popular-web-hosting-software-offered-by-l.mdx
+++ b/iaas/iaas-faqs/is-there-macos-software-to-replace-the-popular-web-hosting-software-offered-by-l.mdx
@@ -12,23 +12,6 @@ labels: ["host", "faq", "linux", "macOS", "hosting", "vps"]
 suggested_new_path: "/iaas/iaas-faqs/is-there-macos-software-to-replace-the-popular-web-hosting-software-offered-by-l"
 ---
 
-{/* schema:injected */}
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "Is there macOS software to replace the popular web hosting software offered by Linux VPS providers?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Below are some tools that allow users to exploit the power and reliability of the Apple macOS platform, and still have the familiar NIX-type experience. macOS Server by Apple is available in the App Store for $19.99 and installs as an app and service within macOS. It includes a web server among other utilities. MAMP / MAMP Pro is similar to Linux LAMP. \u201cMAMP\u201d stands for Macintosh, Apache, MySQL and PHP. MAMP can be installed on macOS 10.10 or greater and includes a friendly user interface. MACPo"
-      }
-    }
-  ]
-}
-</script>
 
 Below are some tools that allow users to exploit the power and reliability of the Apple macOS platform, and still have the familiar *NIX-type experience.
 

--- a/iaas/iaas-faqs/what-are-macstadiums-proprietary-mac-pro-upgrades.mdx
+++ b/iaas/iaas-faqs/what-are-macstadiums-proprietary-mac-pro-upgrades.mdx
@@ -12,23 +12,6 @@ labels: ["hardware", "mac", "faq", "pro", "upgrade", "upgrades", "mac pro"]
 suggested_new_path: "/iaas/iaas-faqs/what-are-macstadiums-proprietary-mac-pro-upgrades"
 ---
 
-{/* schema:injected */}
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "What are MacStadium\u2019s proprietary Mac Pro upgrades?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Dual power, dual 10G ethernet, fibre channel (which allows you to access SAN in a cloud environment)."
-      }
-    }
-  ]
-}
-</script>
 
 Dual power, dual 10G ethernet, fibre channel (which allows you to access SAN in a cloud environment).
 

--- a/iaas/iaas-faqs/what-do-i-do-if-i-accidentally-turned-off-vnc-on-my-hosted-mac.mdx
+++ b/iaas/iaas-faqs/what-do-i-do-if-i-accidentally-turned-off-vnc-on-my-hosted-mac.mdx
@@ -12,23 +12,6 @@ labels: ["hardware", "faq", "vnc", "off"]
 suggested_new_path: "/iaas/iaas-faqs/what-do-i-do-if-i-accidentally-turned-off-vnc-on-my-hosted-mac"
 ---
 
-{/* schema:injected */}
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "What do I do if I accidentally turned off VNC on my hosted Mac?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "If you inadvertently turn off VNC / ARD on your hosted Mac, you can re-enable it through a console connection via SSH (which MacStadium turns on by default on all subscription based Mac servers) with these instructions: IMPORTANT! If your Mac mini is running macOS 10.14 or higher DO NOT run the following commands in the terminal. They will put the OS in view-only mode. If you are accessing the hosted Mac from a local computer running OS X, you can click on Spotlight, and type \u2018terminal\u2019. Once in"
-      }
-    }
-  ]
-}
-</script>
 
 If you inadvertently turn off VNC / ARD on your hosted Mac, you can re-enable it through a console connection via SSH (which MacStadium turns on by default on all subscription based Mac servers) with these instructions:
 

--- a/iaas/iaas-faqs/what-is-instant-provisioning-and-how-long-does-it-take.mdx
+++ b/iaas/iaas-faqs/what-is-instant-provisioning-and-how-long-does-it-take.mdx
@@ -12,23 +12,6 @@ labels: ["faq", "provision", "provisioning", "instant"]
 suggested_new_path: "/iaas/iaas-faqs/what-is-instant-provisioning-and-how-long-does-it-take"
 ---
 
-{/* schema:injected */}
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "What is instant provisioning and how long does it take?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Instant provisioning is MacStadium developed technology that allows us to deliver ready-to-go dedicated servers to customers 24x7x365 within seconds of checkout. When you complete checkout, an installation ticket is opened. If the requested server is available for instant provisioning, the ticket will be automatically closed by our systems and an email sent to you which includes your server's IP address and user login credentials (username and password). We typically have 50-100 servers ready to"
-      }
-    }
-  ]
-}
-</script>
 
 Instant provisioning is MacStadium developed technology that allows us to deliver ready-to-go dedicated servers to customers 24x7x365 within seconds of checkout.
 

--- a/iaas/iaas-faqs/whats-the-ola-on-rebooting-a-dedicated-mac-host.mdx
+++ b/iaas/iaas-faqs/whats-the-ola-on-rebooting-a-dedicated-mac-host.mdx
@@ -12,23 +12,6 @@ labels: ["hardware", "host", "mac", "faq", "ola", "reboot", "rebooting"]
 suggested_new_path: "/iaas/iaas-faqs/whats-the-ola-on-rebooting-a-dedicated-mac-host"
 ---
 
-{/* schema:injected */}
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "What\u2019s the OLA on rebooting a dedicated Mac host?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Our operational-level (OLA) standard on a reboot of a dedicated Mac is two hours, though in most cases it is completed in less time."
-      }
-    }
-  ]
-}
-</script>
 
 Our operational-level (OLA) standard on a reboot of a dedicated Mac is two hours, though in most cases it is completed in less time.
 

--- a/iaas/iaas-faqs/why-are-coreaudiod-and-launchd-using-a-high-amount-of-resources.mdx
+++ b/iaas/iaas-faqs/why-are-coreaudiod-and-launchd-using-a-high-amount-of-resources.mdx
@@ -12,23 +12,6 @@ labels: ["faq", "coreaudiod", "resources"]
 suggested_new_path: "/iaas/iaas-faqs/why-are-coreaudiod-and-launchd-using-a-high-amount-of-resources"
 ---
 
-{/* schema:injected */}
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "Why are coreaudiod and launchd using a high amount of resources?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Disclaimer: We are an infrastructure provider and can only offer a minimal amount of help for software issues. We can not guarantee this fix works for all users or offer support for it. Please contact the software developer (Apple, in this case) for further help. We can also provide a list of vendors that we work with to support you. We found a confirmed solution with the help of a customer: \"I figured out what the problem was in case you all are seeing this in other places. The bluetooth daemon"
-      }
-    }
-  ]
-}
-</script>
 
 Disclaimer: We are an infrastructure provider and can only offer a minimal amount of help for software issues. We can not guarantee this fix works for all users or offer support for it. Please contact the software developer (Apple, in this case) for further help. We can also provide a list of vendors that we work with to support you.
 

--- a/macstadium/account-management-and-saml/enable-saml-sso-with-azure-active-directory.mdx
+++ b/macstadium/account-management-and-saml/enable-saml-sso-with-azure-active-directory.mdx
@@ -12,44 +12,6 @@ labels: ["sso", "saml", "azure", "active directory"]
 suggested_new_path: "/macstadium/account-management-and-saml/enable-saml-sso-with-azure-active-directory"
 ---
 
-{/* schema:injected */}
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "HowTo",
-  "name": "Enable SAML SSO with Azure Active Directory",
-  "step": [
-    {
-      "@type": "HowToStep",
-      "text": "Navigate to **Enterprise applications**."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "Create a new application by clicking **New Application**."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "Create an application by clicking **Create your own application**."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "Click **Edit** on the _Basic SAML settings._"
-    },
-    {
-      "@type": "HowToStep",
-      "text": "Configure SAML (Steps 11 to 15)"
-    },
-    {
-      "@type": "HowToStep",
-      "text": "**IMPORTANT** : Next, edit the Attributes & Claims for your SAML app. You will need the email field to be mapped to user.mail."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "Once the attributes & claims are updated, please provide our support team with the app federation metadata URL. You can copy the federation metadata URL in section 3 of your SAML app, as shown in the below screenshot."
-    }
-  ]
-}
-</script>
 
 ## About
 

--- a/macstadium/account-management-and-saml/enable-saml-sso-with-google-workspace-federation.mdx
+++ b/macstadium/account-management-and-saml/enable-saml-sso-with-google-workspace-federation.mdx
@@ -12,44 +12,6 @@ labels: ["federation", "sso", "google", "saml", "workspace"]
 suggested_new_path: "/macstadium/account-management-and-saml/enable-saml-sso-with-google-workspace-federation"
 ---
 
-{/* schema:injected */}
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "HowTo",
-  "name": "Enable SAML SSO with Google Workspace Federation",
-  "step": [
-    {
-      "@type": "HowToStep",
-      "text": "Go to [Google Admin Console](https://admin.google.com/)"
-    },
-    {
-      "@type": "HowToStep",
-      "text": "Navigate to \u201cWeb and mobile apps\u201d (Apps \u2192 Web and mobile apps in the left menu or use [this link](https://admin.google.com/ac/apps/unified))"
-    },
-    {
-      "@type": "HowToStep",
-      "text": "Create a new \u201cCustom SAML App\u201d (click Add app)"
-    },
-    {
-      "@type": "HowToStep",
-      "text": "Enter \u201cApp name\u201d (e.g. MacStadium Portal)"
-    },
-    {
-      "@type": "HowToStep",
-      "text": "Download the metadata by clicking Download Metadata - Keep this file for sharing with our support team later."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "Click Finish to complete the setup"
-    },
-    {
-      "@type": "HowToStep",
-      "text": "Provide our support team with the metadata file from step 5"
-    }
-  ]
-}
-</script>
 
 SAML SSO is a paid offering. Please contact your account team through the portal for more information.
 

--- a/remote-desktop-vdi/cloud-access-legacy/connect-to-your-cloud-ssh.mdx
+++ b/remote-desktop-vdi/cloud-access-legacy/connect-to-your-cloud-ssh.mdx
@@ -16,36 +16,6 @@ suggested_new_path: "/remote-desktop-vdi/cloud-access-legacy/connect-to-your-clo
   **Cloud Access is no longer sold directly by MacStadium.** Renewals are supported, but new customers should purchase [HP Anyware](https://anyware.hp.com/) directly. This documentation is preserved for existing customers. For remote macOS access, see [Orka for VDI](/remote-desktop-vdi/orka-for-vdi-deployment/overview-architecture). Questions? Contact [support@macstadium.com](mailto:support@macstadium.com).
 </Warning>
 
-{/* schema:injected */}
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "HowTo",
-  "name": "Connect to Your Cloud (SSH)",
-  "step": [
-    {
-      "@type": "HowToStep",
-      "text": "Navigate to your ESXi server\u2019s embedded host client using the IP address or domain name."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "Select Manage in the left sidebar Navigator to access the settings for your host"
-    },
-    {
-      "@type": "HowToStep",
-      "text": "Highlight the **TSM-SSH service (SSH)** and either right-click or use the menu item at the top of the window to select Start."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "Persistent SSH access across ESXi host reboots"
-    },
-    {
-      "@type": "HowToStep",
-      "text": "By right-clicking on a service or clicking the Actions menu item, you can adjust the policy for the service. This means you can set the service to remain on based on firewall ports or with the host and after restart."
-    }
-  ]
-}
-</script>
 
 MacStadium understands that your workflow shouldn't need to be retooled to use our infrastructure as a service. To that end, we also offer simple connections to your private cloud via SSH.
 

--- a/remote-desktop-vdi/cloud-access-legacy/connect-to-your-cloud-via-vpn.mdx
+++ b/remote-desktop-vdi/cloud-access-legacy/connect-to-your-cloud-via-vpn.mdx
@@ -16,56 +16,6 @@ suggested_new_path: "/remote-desktop-vdi/cloud-access-legacy/connect-to-your-clo
   **Cloud Access is no longer sold directly by MacStadium.** Renewals are supported, but new customers should purchase [HP Anyware](https://anyware.hp.com/) directly. This documentation is preserved for existing customers. For remote macOS access, see [Orka for VDI](/remote-desktop-vdi/orka-for-vdi-deployment/overview-architecture). Questions? Contact [support@macstadium.com](mailto:support@macstadium.com).
 </Warning>
 
-{/* schema:injected */}
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "HowTo",
-  "name": "Connect to Your Cloud (via VPN)",
-  "step": [
-    {
-      "@type": "HowToStep",
-      "text": "Open the IP Plan from MacStadium Portal > account menu > Files."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "Open the file and locate the VPN Server section."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "From the browser, visit `https://<YOUR_VPN_SERVER_ADDRESS_HERE>`."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "When prompted, provide the VPN credentials from the IP Plan."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "Log in using the username and password given to you in your IP Plan."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "Cisco AnyConnect SecureMobility will then check to see if your personal computer has Java installed. If it is installed, Java will be used. If not, you will be given a direct download link. Simply click the link to begin the download and subsequent installation process."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "Follow the installation prompts to complete the install."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "Once installation has completed:"
-    },
-    {
-      "@type": "HowToStep",
-      "text": "From the main screen, enter the IP Address provided in your IP Plan, and click connect."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "Finally, to connect to your private MacStadium Cloud, simply enter your username and password once more."
-    }
-  ]
-}
-</script>
 
 After signup, an IP Plan is sent, which contains all the information for setup and configuration access to the cloud environment. The recommended method of access is via a Virtual Private Network (VPN), which provides an easy to implement and secure connection.
 

--- a/remote-desktop-vdi/cloud-access-legacy/connect-to-your-cloud-windows.mdx
+++ b/remote-desktop-vdi/cloud-access-legacy/connect-to-your-cloud-windows.mdx
@@ -16,56 +16,6 @@ suggested_new_path: "/remote-desktop-vdi/cloud-access-legacy/connect-to-your-clo
   **Cloud Access is no longer sold directly by MacStadium.** Renewals are supported, but new customers should purchase [HP Anyware](https://anyware.hp.com/) directly. This documentation is preserved for existing customers. For remote macOS access, see [Orka for VDI](/remote-desktop-vdi/orka-for-vdi-deployment/overview-architecture). Questions? Contact [support@macstadium.com](mailto:support@macstadium.com).
 </Warning>
 
-{/* schema:injected */}
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "HowTo",
-  "name": "Connect to Your Cloud (Windows)",
-  "step": [
-    {
-      "@type": "HowToStep",
-      "text": "Go to the Shrew Soft Inc. website at \\<https://www.shrew.net/download/vpn> and download the VPN client for Windows."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "Run the installer and follow the prompts. When asked, select Standard Edition."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "After the installation completes, find and run the VPN Access Manager."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "Enter the IP address of your firewall WAN IP."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "Go to the Authentication tab. From the Authentication Method drop-down menu select Mutual PSK + XAuth."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "On the Local Identity sub-tab, in the FQDN String text box, enter your group authentication name."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "On the Credentials sub-tab, in the Pre Shared Key text box enter your group authentication password. Click Save."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "On the home screen, select the now available VPN."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "When prompted, enter your VPN credentials and click Connect."
-    },
-    {
-      "@type": "HowToStep",
-      "text": "When you see Tunnel enabled, you are connected to the VPN."
-    }
-  ]
-}
-</script>
 
 The Cisco VPN client for Windows is now deprecated. If you need to connect to your MacStadium cloud from a Windows machine, you can use the free Shrew Soft VPN client instead.
 


### PR DESCRIPTION
## What

Removes `<script type="application/ld+json">` blocks that `inject-schema-markup.py` added to 16 MDX files.

## Why it's failing

MDX doesn't treat `<script>` tag content as raw HTML — acorn (the JS parser MDX uses) tries to parse the contents as JavaScript expressions. Raw JSON objects with `{` `}` throw `Could not parse expression with acorn`, blocking every deployment that touches these files.

PR #17 fixed the `<!-- -->` HTML comment (also invalid MDX), but exposed this deeper issue in all 16 files.

## Why removing is the right call

Schema markup via inline `<script>` injection isn't valid MDX regardless of tooling. Mintlify's schema markup support is a **P1 post-launch item** — it gets configured through frontmatter per article type, not raw script injection. That work is tracked in DI-513 scope (post-launch).

## Files changed

All 16 files from PR #17 — 393 lines removed.

## Test plan

- [ ] Mintlify deployment check passes
- [ ] No `<script`, `schema:injected`, or `application/ld+json` in any `.mdx` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)