### PR TITLE
Enable Suggest Edits and Raise Issue buttons

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -17,6 +17,14 @@
       {"name": "Portal", "url": "https://portal.macstadium.com"}
     ]
   },
+  "github": {
+    "owner": "macstadium",
+    "repo": "macstadium-docs"
+  },
+  "feedback": {
+    "suggestEdit": true,
+    "raiseIssue": true
+  },
   "navigation": {
     "versions": [
       {


### PR DESCRIPTION
## Summary

- Adds `github` config (owner + repo) so Mintlify knows where to point the Suggest Edits button
- Adds `feedback.suggestEdit` and `feedback.raiseIssue` to enable the buttons on every article

Without the `github` block, Mintlify suppresses the button even when the repo is public.

## Test plan

- [x] Deployment check passes
- [x] Suggest Edits button visible on article pages on docs.macstadium.com
- [ ] Clicking it opens the correct GitHub edit flow (not a 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)