### PR TITLE
Generalize Apple Silicon resize → upgrade limitation to all macOS versions

### DIFF
--- a/orka/orka-resources/apple-silicon-based-support.mdx
+++ b/orka/orka-resources/apple-silicon-based-support.mdx
@@ -115,8 +115,5 @@ Below is a list of the ones that are not applicable to Apple silicon-based VMs:
 
   5. Starting with [Orka 2.4.0](https://orkadocs.macstadium.com/docs/orka-v240), shared VM storage is **deprecated** for Apple silicon-based VMs running macOS Monterey and **will be removed** in Orka 2.5.0. To continue using shared VM storage with Orka 2.5.0 and later, you will need to upgrade your Apple Silicon-based Monterey VMs to macOS Ventura, OR switch to Intel-based Monterey VMs.
 
-  6. After you resize an Apple silicon-based VM running macOS Ventura and attempt to upgrade to a newer macOS version, the upgrade might fail or you might experience other issues with your VM. This is a limitation of the current resize design and the Apple virtualization framework.  
-**Workaround:** If possible, upgrade the image before resizing.
-
-  7. After you resize an Apple silicon-based VM running macOS Monterey and attempt to upgrade to a newer macOS version, the upgrade might fail or you might experience other issues with your VM. This is a limitation of the current resize design and the Apple virtualization framework.  
-**Workaround:** If possible, upgrade the image before resizing.
+  6. After you resize an Apple silicon-based VM and attempt to upgrade to a newer macOS version, the upgrade might fail or you might experience other issues with your VM. This is a limitation of the Apple Virtualization framework and applies to all macOS versions.
+**Workaround:** Upgrade the macOS image before resizing. If you have already resized, deploy a fresh VM from an unresized image and upgrade from there.


### PR DESCRIPTION
## Summary

- Items 6 and 7 in the Limitations section were identical except for the macOS version name (Ventura / Monterey)
- The limitation is a property of the Apple Virtualization framework, not tied to any specific macOS release — applies to Sonoma, Sequoia, and beyond
- Consolidated into a single item covering all macOS versions
- Added a workaround for users who have already resized (deploy fresh from unresized image)

Prompted by a customer question in Slack asking whether this applied to newer macOS versions.

## Test plan

- [x] Deployment check passes
- [x] Limitations section renders correctly — item 6 covers all macOS versions, no item 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)