### PR TITLE
Enable telemetry to unblock Suggest Edits button

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -25,6 +25,11 @@
     "suggestEdit": true,
     "raiseIssue": true
   },
+  "integrations": {
+    "telemetry": {
+      "enabled": true
+    }
+  },
   "navigation": {
     "versions": [
       {


### PR DESCRIPTION
## Summary

- Adds `integrations.telemetry.enabled: true` to `docs.json`
- Mintlify requires telemetry enabled for feedback features (including Suggest Edits) to render — without it the button is suppressed regardless of the `feedback.suggestEdit` config

## Test plan

- [x] Merge and redeploy
- [ ] Verify Suggest Edits button appears on an article page at docs.macstadium.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)