### PR TITLE
Fix Vale config: move Vocab above syntax blocks

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,7 +1,6 @@
 StylesPath = styles
+Vocab = Mintlify
 
 [*.mdx]
 BasedOnStyles = Vale
 Vale.Spelling = YES
-
-Vocab = Mintlify


### PR DESCRIPTION
## Summary

Fixes E201 — `Vocab` is a core Vale option and must be defined in the global section, before any `[*.mdx]` blocks.

## Test plan

- [ ] Verify `vale-spellcheck` passes without the E201 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)