### PR TITLE
Docs QA polish: code blocks, callouts, headings, next steps

### DIFF
--- a/macstadium/support/support.mdx
+++ b/macstadium/support/support.mdx
@@ -24,7 +24,9 @@ MacStadium offers various First-Line Support Services 24/7 for customers on the 
 
 ### Advanced Engineering Support
 
-📘 Customers on the Business, Pro and Premium support plans can get 24/7 Engineering Team Support
+<Note>
+  Customers on the Business, Pro and Premium support plans can get 24/7 Engineering Team Support
+</Note>
 
   * Networking, storage, and virtualization expertise
   * Break/fix, upgrades, advice, troubleshooting
@@ -110,9 +112,13 @@ Creating a ticket through MacStadium's [customer portal](https://portal.macstadi
 
 
 
-📘 Contact MacStadium if any unexplained performance degradation occurs.
+<Note>
+  Contact MacStadium if any unexplained performance degradation occurs.
+</Note>
 
-👍 **MacStadium engineers can troubleshoot and return your infrastructure to optimal performance**
+<Note>
+  MacStadium engineers can troubleshoot and return your infrastructure to optimal performance.
+</Note>
 
 ### Monitoring alerts
 
@@ -123,6 +129,8 @@ Creating a ticket through MacStadium's [customer portal](https://portal.macstadi
 
 ## Subscribe
 
-\<http://status.macstadium.com/>
+[status.macstadium.com](http://status.macstadium.com/)
 
-👍 Shows current status of each data center and is the ideal place to stay up-to-date on scheduled maintenance or unplanned outages.
+<Note>
+  Shows current status of each data center and is the ideal place to stay up-to-date on scheduled maintenance or unplanned outages.
+</Note>

--- a/orka/orka-overview/orka-overview.mdx
+++ b/orka/orka-overview/orka-overview.mdx
@@ -63,9 +63,9 @@ This document will focus on using k8s as the control plane for Orka. For details
 
 
 
-> 🗒️NOTE
-> 
-> Orka running in the MacStadium Cloud or AWS may be behind a firewall and may require a VPN to access.
+<Note>
+  Orka running in the MacStadium Cloud or AWS may be behind a firewall and may require a VPN to access.
+</Note>
 
 ## Terminology
 
@@ -118,11 +118,11 @@ Once installed and configured, the following steps and commands quickly introduc
 
 
 
-> 🗒️NEXT STEPS
-> 
-> Take the customized VM and integrate it with a CI tool.
+<Note>
+  Take the customized VM and integrate it with a CI tool.
+</Note>
 
-## 1\. First Time Setup
+## 1. First Time Setup
 
 **Review IP Plan and Setup Networking**
 
@@ -161,11 +161,11 @@ If deploying within AWS or On-Prem, make sure to connect to the network such tha
 
 
 
-> 🗒️NOTE
-> 
-> Invite users in the Portal via the [**Users- >Add New Users**](/orka/orka-cluster-access/customer-portal-manage-account-users) flow.
+<Note>
+  Invite users in the Portal via the [**Users- >Add New Users**](/orka/orka-cluster-access/customer-portal-manage-account-users) flow.
+</Note>
 
-## 2\. Run orka3 Login to Sign into the Control Plane
+## 2. Run orka3 Login to Sign into the Control Plane
 
 orka3 is the CLI to interface with the Orka. Once connected to the VPN or mesh network, login and retrieve a token that can be used for subsequent interactions.
 
@@ -186,7 +186,7 @@ orka3 is the CLI to interface with the Orka. Once connected to the VPN or mesh n
 
 
 
-## 3\. Learn the 3 Main Objects
+## 3. Learn the 3 Main Objects
 
 **Nodes** , **images** , and **VMs**
 
@@ -196,7 +196,7 @@ orka3 is the CLI to interface with the Orka. Once connected to the VPN or mesh n
 
 
 
-## 4\. Deploy and Connect to a New VM
+## 4. Deploy and Connect to a New VM
 
   * Launch a VM from a base image, including options to load from the OCI registry.
   * For legacy users, there is a demonstrated loading from an NFS mount.
@@ -204,18 +204,18 @@ orka3 is the CLI to interface with the Orka. Once connected to the VPN or mesh n
 
 
 
-> 🗒️NOTE
-> 
-> To deploy a VM, an image is required. Check the MacStadium registry on ghcr.io and pull an image, if the local image list is empty, or use an image from an OCI-compatible registry. Check \<https://github.com/macstadium/orka-images> for the latest available OCI-compatible images provided by MacStadium. The images available out-of-the-box provide a pre-configured disk size and a pre-installed OS.
+<Note>
+  To deploy a VM, an image is required. Check the MacStadium registry on ghcr.io and pull an image, if the local image list is empty, or use an image from an OCI-compatible registry. Check [https://github.com/macstadium/orka-images](https://github.com/macstadium/orka-images) for the latest available OCI-compatible images provided by MacStadium. The images available out-of-the-box provide a pre-configured disk size and a pre-installed OS.
+</Note>
 
-## 5\. Modify, Save, and Stop the VM
+## 5. Modify, Save, and Stop the VM
 
   * Install dependencies or configure the environment for CI builds.
   * Once customized, save the VM configuration as a new image for future use.
 
 
 
-## 6\. Manage Image Caches
+## 6. Manage Image Caches
 
 Manage images stored on Orka nodes. By adding images to a node before deployment of a VM using that base image, DevOps and engineering staff can manage and control the delay caused by remote or even local cluster storage image pulls, providing consistent deployment times.
 

--- a/orka/orka-upgrades-and-release-notes/orka-upgrades.mdx
+++ b/orka/orka-upgrades-and-release-notes/orka-upgrades.mdx
@@ -35,23 +35,25 @@ This is the most common type of Orka upgrade. Orka releases bring new CLI and AP
 Make sure that during the maintenance window there are no running workflows (for example, deploying a VM and running a build.).  
 As part of this upgrade, you might need to [download and install](/orka/orka-overview/tools-integrations) a new Orka CLI version.
 
-Aspect | Notes  
----|---  
-Maintenance window | Up to 3 hours.  
-  
-Must be scheduled with the MacStadium support team.  
-Access to the environment | During the maintenance window, the environment is inaccessible.  
-  
-After the maintenance window, access to the environment is restored. You can reach your environment at the original IP, Orka domain, or external custom domain.  
-Orka users | Orka users persist.  
-Service Accounts | Your custom service accounts persist.  
-  
-PLEASE NOTE: Your Service Account Tokens will need to be regenerated after the upgrade.  
-VMs and VM configs |  VM configs persist. VMs may be deleted. After the upgrade completes, you can redeploy them from the respective VM configs.  
-Images and ISOs | Images and ISOs persist.  
-Image cache (Apple silicon nodes) | The image cache is removed from each node.  
-Namespaces | Your custom namespaces persist.  
-RoleBindings | Your custom permissions persist.  
+<Warning>
+  Service Account tokens must be regenerated after this upgrade. Any automated workflows using service account tokens will fail until tokens are regenerated with `orka3 serviceaccount token <name>`.
+</Warning>
+
+Aspect | Notes
+---|---
+Maintenance window | Up to 3 hours.
+
+Must be scheduled with the MacStadium support team.
+Access to the environment | During the maintenance window, the environment is inaccessible.
+
+After the maintenance window, access to the environment is restored. You can reach your environment at the original IP, Orka domain, or external custom domain.
+Orka users | Orka users persist.
+Service Accounts | Your custom service accounts persist.
+VMs and VM configs | VM configs persist. VMs may be deleted. After the upgrade completes, you can redeploy them from the respective VM configs.
+Images and ISOs | Images and ISOs persist.
+Image cache (Apple silicon nodes) | The image cache is removed from each node.
+Namespaces | Your custom namespaces persist.
+RoleBindings | Your custom permissions persist.
 Kubernetes Pods and services | Your custom Pods and services persist.  
   
 ### Virtualization and orchestration layer upgrades (Kubernetes, Docker, or Linux)
@@ -63,26 +65,28 @@ Occasionally, the Orka team upgrades the components of the virtualization and or
   * Make sure that during the maintenance window there are no running workflows (for example, deploying a VM and running a build.).
   * If this is a Kubernetes upgrade and you are working with the Kubernetes layer directly, make sure to address any deprecated APIs.
 
-Aspect | Notes  
----|---  
-Maintenance window | Up to 3 hours  
-  
-Must be [scheduled](/orka/orka-upgrades-and-release-notes/orka-upgrades#requesting-an-upgrade) with the MacStadium support team.  
-Access to the environment | During the maintenance window, the environment is inaccessible.  
-  
-After the maintenance window, the access to the environment is restored. You can reach your environment at the original IP, Orka domain, or external custom domain.  
-Orka users | Orka users persist.  
-Service Accounts | Your custom service accounts persist.  
-  
-PLEASE NOTE: Your Service Account Tokens will need to be regenerated after the upgrade.  
-VMs and VM configs | VM configs persist.  
-  
-VMs are deleted. After the upgrade completes, you can redeploy them from the respective VM configs.  
-Registry credentials | Registry credentials do not persist, and will need to be regenerated after the upgrade.  
-Images & ISOs | Images and ISOs persist.  
-Image cache (Apple silicon nodes) | The image cache is removed from each node.  
-Namespaces | Your custom namespaces persist.  
-RoleBindings | Your custom permissions persist.  
-Kubernetes Pods and services | Your custom Pods and services are lost.  
-  
+<Warning>
+  Service Account tokens must be regenerated after this upgrade. Any automated workflows using service account tokens will fail until tokens are regenerated with `orka3 serviceaccount token <name>`.
+</Warning>
+
+Aspect | Notes
+---|---
+Maintenance window | Up to 3 hours
+
+Must be [scheduled](/orka/orka-upgrades-and-release-notes/orka-upgrades#requesting-an-upgrade) with the MacStadium support team.
+Access to the environment | During the maintenance window, the environment is inaccessible.
+
+After the maintenance window, the access to the environment is restored. You can reach your environment at the original IP, Orka domain, or external custom domain.
+Orka users | Orka users persist.
+Service Accounts | Your custom service accounts persist.
+VMs and VM configs | VM configs persist.
+
+VMs are deleted. After the upgrade completes, you can redeploy them from the respective VM configs.
+Registry credentials | Registry credentials do not persist, and will need to be regenerated after the upgrade.
+Images & ISOs | Images and ISOs persist.
+Image cache (Apple silicon nodes) | The image cache is removed from each node.
+Namespaces | Your custom namespaces persist.
+RoleBindings | Your custom permissions persist.
+Kubernetes Pods and services | Your custom Pods and services are lost.
+
 You need to recreate them.

--- a/orka/quick-start-guides/cicd-integrations-quick-start.mdx
+++ b/orka/quick-start-guides/cicd-integrations-quick-start.mdx
@@ -35,7 +35,7 @@ The Orka CI/CD integrations will be most useful to:
 
 
 
-## 1\. Before you begin
+## 1. Before you begin
 
   1. Make sure you can access the account for your cluster in the MacStadium Customer Portal. See [Cluster Access Management: Overview](/orka/orka-cluster-access/cluster-access-management-overview).
   2. Get your VPN connection information from your IP Plan. You can [download](/macstadium/macstadium-overview/ip-plan) it from the [MacStadium portal](https://portal.macstadium.com/).
@@ -46,7 +46,7 @@ The Orka CI/CD integrations will be most useful to:
 
 
 
-## 2\. Some Orka CI/CD basics
+## 2. Some Orka CI/CD basics
 
   * CI/CD integrations must target your Orka API URL. If you are using an [Orka domain](/orka/networking-with-orka-at-macstadium/built-in-orka-domains) or an [external custom domain](/orka/networking-with-orka-at-macstadium/external-custom-domains), you must ensure that the CI/CD integration can resolve the domain.
 
@@ -77,41 +77,41 @@ A running VM that persists between the iterations of your CI/CD pipeline. This V
 
 A new VM that spins up and lives for the duration of the CI/CD pipeline iteration. After the iteration is complete, the VM is destroyed.
 
-## 3\. Pick your CI/CD integration
+## 3. Pick your CI/CD integration
 
 Go to [Orka Tools & Integrations](/orka/orka-overview/tools-integrations) and review the latest list of available integrations. Pick the one you want to use and navigate to its detailed setup instructions (usually available in the respective repo or official integration page).
 
-## 4\. Create a service account and get a token
+## 4. Create a service account and get a token
 
 Orka clusters now require authentication via Single Sign-On or via service account token.
 
 Service accounts are intended for use with CI/CD integrations. They don't require username/password credentials to log in and let CI/CD integrations bypass the browser login via the Orka3 CLI. The tokens for service accounts also have an extended duration of 1 year.
-    
-    
-```
-orka3 sa create <SERVICE_ACCOUNT_NAME>  
+
+
+```bash
+orka3 sa create <SERVICE_ACCOUNT_NAME>
 orka3 sa token <SERVICE_ACCOUNT_NAME>
 ```
 Grab the token from the response and use it to authenticate the CI/CD integration with the Orka cluster.
 
 These commands create a service account in the `orka-default` namespace and obtain a valid token for it. If you need your CI/CD integration to be able to work in additional namespaces, you need to create the service account in the respective namespace or [configure the respective role bindings](/orka/orka-cluster-access/orka-cluster-manage-access-to-resources).
 
-## 5\. Create the template for your permanent or ephemeral agent
+## 5. Create the template for your permanent or ephemeral agent
 
   1. Check if there are any VM configs on your environment.
 
 
-    
-    
-```
+
+
+```bash
 orka3 vm-config list
 ```
   2. List the available base images that you can use to create a VM config.
 
 
-    
-    
-```
+
+
+```bash
 orka3 image list
 ```
 You will likely see a `sonoma-90gb-orka3-arm` item. It is a fully installed and configured Apple Silicon-based macOS Sonoma image with a 90GB disk size. It also has an admin user configured, SSH and Apple Screen Sharing access enabled, and Orka VM Tools installed.
@@ -135,9 +135,9 @@ A template for an Orka virtual machine. You can deploy multiple VM instances (VM
 Starting with Orka 3.0.0, you can deploy VMs using images from OCI-compatible registries. 
 
 So, instead of using the `sonoma-90gb-orka3-arm` image, you can use our latest Sonoma image from GitHub packages. 
-    
-    
-```
+
+
+```bash
 orka3 vmc create <NAME> --image ghcr.io/macstadium/orka-images/sonoma:latest --cpu 4
 ```
 **VM configuration name limitations**
@@ -161,7 +161,7 @@ A deployed instance of a VM config. VMs take up resources from your nodes and re
 
 If you're using another image as your starting point or if you are installing your OS from ISO, you will likely not have SSH or Screen Sharing enabled by default (even though the respective ports will be mapped by default). In this case, you need to connect to the VM via VNC. You can then enable SSH and Screen Sharing connectivity in the OS.
 
-## 6\. Complete the CI/CD setup
+## 6. Complete the CI/CD setup
 
 Revisit the setup instructions for your preferred Orka CI/CD integration. Fill in any configuration fields as needed.
 
@@ -170,3 +170,15 @@ Note that you might need to provide the SSH credentials for the VM.
 **What are the credentials for my VM config?**
 
 By default, the `sonoma-90gb-orka3-arm` image is configured with an `admin/admin` set of credentials.
+
+## Next steps
+
+Pick your integration and follow the guide for your CI/CD platform:
+
+- [GitHub Actions](/orka/orka-devops-integrations/github-actions)
+- [GitLab CI](/orka/orka-devops-integrations/gitlab)
+- [Jenkins](/orka/orka-devops-integrations/jenkins)
+- [Buildkite](/orka/orka-devops-integrations/buildkite)
+- [TeamCity](/orka/orka-devops-integrations/teamcity)
+
+Not sure which to use? See [Tools and Integrations](/orka/orka-overview/tools-integrations) for the full list.

--- a/orka/quick-start-guides/orka3-api-quick-start.mdx
+++ b/orka/quick-start-guides/orka3-api-quick-start.mdx
@@ -87,43 +87,42 @@ All sample responses are piped through a JSON formatting service. Your responses
 For all API calls, you need to provide the `Authorization: Bearer <TOKEN>` header. The Orka3 API currently does not let you log in from it directly and obtain a token. You will need to obtain your token from the Orka3 CLI.
 
 Orka lets you log in with your MacStadium Customer Portal credentials. Based on the role configured in the Customer Portal, you will have administrative or regular user privileges. By default, you will have access to the `orka-default` namespace. If you have been added to additional role bindings, you might be able to access additional namespaces.
-    
-    
-```
+
+
+```bash
 orka3 login
 ```
 Orka will launch a new browser tab (or window) and let you log in via the provided form. After you log in, you can return to the command line and run more `orka3` commands. Your token is stored locally in the `~/.kube/config` file. Note that your token has a validity duration of one hour. Afterward, you must obtain and pass a new token in your CLI or API calls.
 
 You now need to get your Orka authentication token from your `~/.kube/config`:
-    
-    
-```
+
+
+```bash
 orka3 user get-token
 ```
 ## Deploy your first VM instance
 
 Starting with Orka 3.0.0, you can use the built-in Swagger UI to execute API calls directly against your cluster.
 
-In your browser, navigate to `<ORKA_API_URL>/api/v1/swagger`, click **AUthorize** , and type `Bearer <TOKEN>`. For every call that you want to run, just click **Try it out** and fill the required details.
+In your browser, navigate to `<ORKA_API_URL>/api/v1/swagger`, click **Authorize** , and type `Bearer <TOKEN>`. For every call that you want to run, just click **Try it out** and fill the required details.
 
   1. Check the available resources in your cluster:
 
 
 
 **cURL**
-    
-    
-```
-curl -X 'GET' \  
-'<ORKA_API_URL>/api/v1/namespaces/orka-default/nodes' \  
--H 'accept: application/json' \  
+
+```bash
+curl -X 'GET' \
+'<ORKA_API_URL>/api/v1/namespaces/orka-default/nodes' \
+-H 'accept: application/json' \
 -H 'Authorization: Bearer <TOKEN>'
 
 
-**Response**  
-{  
-"items": [  
-{  
+**Response**
+{
+"items": [
+{
 "name": "macpro-4",  
 "namespace": "orka-default",  
 "nodeIP": "10.221.189.11",  
@@ -172,20 +171,18 @@ The resources within a namespace are completely isolated from one another and ca
 
 
 **cURL**
-    
-    
-```
-curl -X 'GET' \  
-'<ORKA_API_URL>/api/v1/namespaces/orka-default/vms' \  
--H 'accept: application/json' \  
+
+```bash
+curl -X 'GET' \
+'<ORKA_API_URL>/api/v1/namespaces/orka-default/vms' \
+-H 'accept: application/json' \
 -H 'Authorization: Bearer <TOKEN>'
 ```
 **Response**
-    
-    
-```
-{  
-"items": []  
+
+```bash
+{
+"items": []
 }
 ```
 This API call lists all VM instances in the `orka-default` namespace. If nothing prints, no one has created any VM instances yet.
@@ -193,12 +190,12 @@ This API call lists all VM instances in the `orka-default` namespace. If nothing
   3. List the available base images that you can use to deploy a VM.
 
 
-    
-    
-```
-curl -X 'GET' \  
-'<ORKA_API_URL>/api/v1/namespaces/orka-default/images' \  
--H 'accept: application/json' \  
+
+
+```bash
+curl -X 'GET' \
+'<ORKA_API_URL>/api/v1/namespaces/orka-default/images' \
+-H 'accept: application/json' \
 -H 'Authorization: Bearer <TOKEN>'
 ```
 You will likely see a `sonoma-90gb-orka3-arm` item in the response. It is a fully installed and configured macOS Sonoma image with a 90GB disk size. It also has an admin user configured and SSH and Apple Screen Sharing access enabled.
@@ -214,29 +211,28 @@ A disk image that represents VM storage. Base images are bootable disk images th
 
 
 **cURL**
-    
-    
-```
-curl -X 'POST' \  
-'<ORKA_API_URL>/api/v1/namespaces/orka-default/vms' \  
--H 'accept: application/json' \  
--H 'Authorization: Bearer <TOKEN>' \  
--H 'Content-Type: application/json' \  
--d '{  
-"image": "sonoma-90gb-orka3-arm"  
+
+```bash
+curl -X 'POST' \
+'<ORKA_API_URL>/api/v1/namespaces/orka-default/vms' \
+-H 'accept: application/json' \
+-H 'Authorization: Bearer <TOKEN>' \
+-H 'Content-Type: application/json' \
+-d '{
+"image": "sonoma-90gb-orka3-arm"
 }'
 
 
-**Response**  
-{  
-"name": "vm-cznfv",  
-"node": "mini-arm-13",  
-"memory": "4.80Gi",  
-"ip": "10.221.189.13",  
-"ssh": 8822,  
-"vnc": 5999,  
-"screenshare": 5901,  
-"status": "Running"  
+**Response**
+{
+"name": "vm-cznfv",
+"node": "mini-arm-13",
+"memory": "4.80Gi",
+"ip": "10.221.189.13",
+"ssh": 8822,
+"vnc": 5999,
+"screenshare": 5901,
+"status": "Running"
 }
 ```
 The bare minimum required argument is `image`.
@@ -248,31 +244,29 @@ Starting with Orka 3.0.0, you can deploy VMs using images from OCI-compatible re
 So, instead of using the `sonoma-90gb-orka3-arm` image, you can use our latest Sonoma image from GitHub packages.
 
 **cURL**
-    
-    
-```
-curl -X 'POST' \  
-'<ORKA_API_URL>/api/v1/namespaces/orka-default/vms' \  
--H 'accept: application/json' \  
--H 'Authorization: Bearer <TOKEN>' \  
--H 'Content-Type: application/json' \  
--d '{  
-"image": "ghcr.io/macstadium/orka-images/sonoma:latest"  
+
+```bash
+curl -X 'POST' \
+'<ORKA_API_URL>/api/v1/namespaces/orka-default/vms' \
+-H 'accept: application/json' \
+-H 'Authorization: Bearer <TOKEN>' \
+-H 'Content-Type: application/json' \
+-d '{
+"image": "ghcr.io/macstadium/orka-images/sonoma:latest"
 }'
 ```
 **Response**
-    
-    
-```
-{  
-"name": "vm-cznfv",  
-"node": "mini-arm-13",  
-"memory": "4.80Gi",  
-"ip": "10.221.189.13",  
-"ssh": 8822,  
-"vnc": 5999,  
-"screenshare": 5901,  
-"status": "Running"  
+
+```bash
+{
+"name": "vm-cznfv",
+"node": "mini-arm-13",
+"memory": "4.80Gi",
+"ip": "10.221.189.13",
+"ssh": 8822,
+"vnc": 5999,
+"screenshare": 5901,
+"status": "Running"
 }
 ```
   5. What happens if you list your VMs again now?
@@ -280,21 +274,19 @@ curl -X 'POST' \
 
 
 **cURL**
-    
-    
-```
-curl -X 'GET' \  
-'<ORKA_API_URL>/api/v1/namespaces/orka-default/vms' \  
--H 'accept: application/json' \  
+
+```bash
+curl -X 'GET' \
+'<ORKA_API_URL>/api/v1/namespaces/orka-default/vms' \
+-H 'accept: application/json' \
 -H 'Authorization: Bearer <TOKEN>'
 ```
 **Response**
-    
-    
-```
-{  
-"items": [  
-{  
+
+```bash
+{
+"items": [
+{
 "name": "vm-l4qgb",  
 "ip": "10.221.189.13",  
 "cpu": 3,  
@@ -324,12 +316,11 @@ When you have a lot of VMs, the response of `GET /resources/vm/list` might becom
 
 
 **cURL**
-    
-    
-```
-curl -X 'GET' \  
-'<ORKA_API_URL>/api/v1/namespaces/orka-default/nodes' \  
--H 'accept: application/json' \  
+
+```bash
+curl -X 'GET' \
+'<ORKA_API_URL>/api/v1/namespaces/orka-default/nodes' \
+-H 'accept: application/json' \
 -H 'Authorization: Bearer <TOKEN>'
 ```
 ## Experience your VM instance
@@ -359,13 +350,13 @@ If you're using another image as your starting point or if you are installing yo
 
 
 
-    
-    
-```
-brew install orka-vm-tools  
-  
-OR  
-  
+
+
+```bash
+brew install orka-vm-tools
+
+OR
+
 brew upgrade orka-vm-tools
 ```
 This action ensures that your VM is running the latest version of the [Orka VM Tools](/orka/orka-resources/vm-tools). This collection of services lets Orka manage the guest operating system on Apple silicon-based VMs more efficiently and enables vital features, such as [shared VM storage](/orka/orka-resources/shared-vm-storage).
@@ -401,52 +392,50 @@ This operation restarts the VM.
 Return to the command line on your local machine and run the following command. You can get the `<VM_NAME>` from the `GET /namespaces/orka-default/vms` output you ran earlier.
 
 **cURL**
-    
-    
-```
-curl -X 'POST' \  
-'<ORKA_API_URL>/api/v1/namespaces/orka-default/vms/<VM_NAME>/commit' \  
--H 'accept: application/json' \  
--H 'Authorization: Bearer <TOKEN>' \  
--H 'Content-Type: application/json' \  
--d '{  
-"description": "Committed from <VM_NAME>"  
-}'  
-  
-OR  
-  
-curl -X 'POST' \  
-'<ORKA_API_URL>/api/v1/namespaces/orka-default/vms/<VM_NAME>/save' \  
--H 'accept: application/json' \  
--H 'Authorization: Bearer <TOKEN>' \  
--H 'Content-Type: application/json' \  
--d '{  
-"description": "Saved from <VM_NAME>",  
-"imageName": "<NEW_IMAGE_NAME>"  
-}'  
-  
-OR  
-  
-curl -X 'POST' \  
-'<ORKA_API_URL>/api/v1/namespaces/orka-default/vms/<VM_NAME>/push' \  
--H 'accept: application/json' \  
--H 'Content-Type: application/json' \  
--d '{  
-"imageReference": "<REGISTRY>/<IMAGE>:<TAG>"  
+
+```bash
+curl -X 'POST' \
+'<ORKA_API_URL>/api/v1/namespaces/orka-default/vms/<VM_NAME>/commit' \
+-H 'accept: application/json' \
+-H 'Authorization: Bearer <TOKEN>' \
+-H 'Content-Type: application/json' \
+-d '{
+"description": "Committed from <VM_NAME>"
+}'
+
+OR
+
+curl -X 'POST' \
+'<ORKA_API_URL>/api/v1/namespaces/orka-default/vms/<VM_NAME>/save' \
+-H 'accept: application/json' \
+-H 'Authorization: Bearer <TOKEN>' \
+-H 'Content-Type: application/json' \
+-d '{
+"description": "Saved from <VM_NAME>",
+"imageName": "<NEW_IMAGE_NAME>"
+}'
+
+OR
+
+curl -X 'POST' \
+'<ORKA_API_URL>/api/v1/namespaces/orka-default/vms/<VM_NAME>/push' \
+-H 'accept: application/json' \
+-H 'Content-Type: application/json' \
+-d '{
+"imageReference": "<REGISTRY>/<IMAGE>:<TAG>"
 }'
 ```
 **Response**
-    
-    
-```
-{  
-"statusUrl": "/api/v1/namespaces/orka-default/images/sonoma-90gb-orka3-arm"  
-}  
-  
-OR  
-  
-{  
-"jobName": "<PUSH_JOB_ID>"  
+
+```bash
+{
+"statusUrl": "/api/v1/namespaces/orka-default/images/sonoma-90gb-orka3-arm"
+}
+
+OR
+
+{
+"jobName": "<PUSH_JOB_ID>"
 }
 ```
   2. See how the changes are preserved for yourself. Deploy a new VM instance from your image:
@@ -454,16 +443,15 @@ OR
 
 
 **cURL**
-    
-    
-```
-curl -X 'POST' \  
-'<ORKA_API_URL>/api/v1/namespaces/orka-default/vms' \  
--H 'accept: application/json' \  
--H 'Authorization: Bearer <TOKEN>' \  
--H 'Content-Type: application/json' \  
--d '{  
-"image": "<IMAGE_NAME>"  
+
+```bash
+curl -X 'POST' \
+'<ORKA_API_URL>/api/v1/namespaces/orka-default/vms' \
+-H 'accept: application/json' \
+-H 'Authorization: Bearer <TOKEN>' \
+-H 'Content-Type: application/json' \
+-d '{
+"image": "<IMAGE_NAME>"
 }'
 ```
   3. Launch Apple Screen Sharing and connect to the newly deployed VM instance. Use the updated admin credentials to log in.
@@ -479,12 +467,11 @@ When your VM instances have served their purpose, you can `delete` them.
 
 
 **cURL**
-    
-    
-```
-curl -X 'DELETE' \  
-'<ORKA_API_URL>/api/v1/namespaces/orka-default/vms/<VM_NAME>' \  
--H 'accept: application/json' \  
+
+```bash
+curl -X 'DELETE' \
+'<ORKA_API_URL>/api/v1/namespaces/orka-default/vms/<VM_NAME>' \
+-H 'accept: application/json' \
 -H 'Authorization: Bearer <TOKEN>'
 ```
   2. List your VMs again.
@@ -493,10 +480,15 @@ curl -X 'DELETE' \
 
 **cURL**
 
-
-```
+```bash
 curl -X 'GET' \
 '<ORKA_API_URL>/api/v1/namespaces/orka-default/vms' \
 -H 'accept: application/json' \
 -H 'Authorization: Bearer <TOKEN>'
 ```
+
+## Next steps
+
+- [CLI Quick Start](/orka/quick-start-guides/orka3-cli-quick-start) — manage VMs interactively with the Orka3 CLI
+- [CI/CD Integrations Quick Start](/orka/quick-start-guides/cicd-integrations-quick-start) — automate VM deployment in your build pipeline
+- [Tools and Integrations](/orka/orka-overview/tools-integrations) — browse available integrations

--- a/orka/quick-start-guides/orka3-cli-quick-start.mdx
+++ b/orka/quick-start-guides/orka3-cli-quick-start.mdx
@@ -47,7 +47,7 @@ The Orka3 CLI will be helpful to:
 
 
 
-## 1\. Before you begin
+## 1. Before you begin
 
   1. Ensure you can access your cluster account in the MacStadium Customer Portal. See [Cluster Access Management: Overview](/orka/orka-cluster-access/cluster-access-management-overview).
   2. Get your VPN connection information from your IP Plan. You can [download](/macstadium/macstadium-overview/ip-plan) it from the [MacStadium portal](https://portal.macstadium.com/).
@@ -57,7 +57,7 @@ The Orka3 CLI will be helpful to:
 
 
 
-## 2\. Download and configure the Orka3 CLI
+## 2. Download and configure the Orka3 CLI
 
   1. Download and install the latest [Orka3 CLI](/orka/orka-overview/tools-integrations) that matches your environment version.
      * On macOS, run the `pkg` executable.
@@ -73,9 +73,9 @@ Try `brew install orka3`.
   2. Launch your preferred command-line tool (e.g., the Terminal on macOS) and run the following command:
 
 
-    
-    
-```
+
+
+```bash
 orka3 config set --api-url <ORKA_API_URL>
 ```
 This operation is a one-time effort. With it, you set the Orka service endpoint for your cluster.
@@ -98,45 +98,45 @@ The Orka3 CLI works only with trusted custom domains and valid TLS certificates 
   3. Enable command autocompletion for the Orka3 CLI
 
 
-    
-    
-```
+
+
+```bash
 orka3 completion {bash|fish|powershell|zsh}
 ```
 The Orka3 CLI prints detailed instructions for the selected shell type.
 
-## 3\. Authenticate with your cluster
+## 3. Authenticate with your cluster
 
 Orka lets you log in with your MacStadium Customer Portal credentials. Your access privileges are based on the role configured by your account admin in the Customer Portal. By default, you will have access to the orka-default namespace. You can access additional namespaces if you have been added to additional role bindings.
-    
-    
-```
+
+
+```bash
 orka3 login
 ```
 Orka will launch a new browser tab (or window) and let you log in via the provided form. After you log in, you can return to the command line and run additional`orka3` commands. Your token is stored locally in the `~/.kube/config` file. Note that your token has a validity duration of one hour. Afterward, you must obtain and pass a new token in your CLI or API calls.
 
-## 4\. Some CLI basics
+## 4. Some CLI basics
 
 The Orka3 CLI is a powerful tool in the hands of both inexperienced and advanced users.
 
 The default Orka3 CLI output for list commands is table-formatted. You can switch to an expanded table format with the `--output wide` flag or to JSON with the `--output json` flag.
 
 To get help, run:
-    
-    
-```
+
+
+```bash
 orka3 help
 orka3 <command> --help
 orka3 <parent_command> <command> --help
 ```
-## 5\. Create and deploy your first VM instance
+## 5. Create and deploy your first VM instance
 
   1. Open a new command-line prompt and run:
 
 
-    
-    
-```
+
+
+```bash
 orka3 nodes list
 ```
 This command shows basic information about the nodes in the `orka-default` namespace. Re-run this command as you deploy VM instances later on to keep track of the available resources on your nodes.
@@ -156,9 +156,9 @@ The resources within a namespace are completely isolated from one another and ca
   2. Run:
 
 
-    
-    
-```
+
+
+```bash
 orka3 vm list
 ```
 This command lists all VM instances in the `orka-default` namespace. If nothing prints, no one has created any VM instances yet.
@@ -170,9 +170,9 @@ Run `orka3 vm list --output wide`.
   3. List the available base images that you can use to deploy a VM:
 
 
-    
-    
-```
+
+
+```bash
 orka3 remote-image list
 ```
 This command shows all of the standard base images in MacStadium's remote repository. You will likely see a `sonoma-90gb-orka3-arm` item. It is a fully installed and configured Apple Silicon-based macOS Sonoma image with a 90GB disk size. It also has an admin user configured, SSH and Apple Screen Sharing access enabled, and Orka VM Tools installed.
@@ -186,9 +186,9 @@ A disk image that represents VM storage. Base images are bootable disk images th
   4. Deploying a VM is as simple as just specifying a base image. Run:
 
 
-    
-    
-```
+
+
+```bash
 orka3 vm deploy --image ghcr.io/macstadium/orka-images/sequoia:latest
 ```
 Orka creates a simple VM with the specified image and 3CPU and assigns a randomly generated name.
@@ -198,9 +198,9 @@ Orka creates a simple VM with the specified image and 3CPU and assigns a randoml
 Starting with Orka 3.0.0, you can deploy VMs using images from OCI-compatible registries.
 
 So, instead of using the `sonoma-90gb-orka3-arm` image, you can use our latest Sonoma image from GitHub packages.
-    
-    
-```
+
+
+```bash
 orka3 vm deploy --image ghcr.io/macstadium/orka-images/sonoma:latest
 ```
   7. Check your nodes and your VMs.
@@ -210,9 +210,9 @@ orka3 vm deploy --image ghcr.io/macstadium/orka-images/sonoma:latest
   * List your VMs:
 
 
-    
-    
-```
+
+
+```bash
 orka3 vm list
 ```
 You should now see your VM in the list.
@@ -223,7 +223,7 @@ For more detailed output, you can run `orka vm list --output wide`. In addition 
 
 When you have a lot of VMs, the output of `orka3 vm list` might become too crowded to use efficiently. Run `orka3 vm list <VM_NAME>` instead and get the system information for a single VM.
 
-## 6\. Experience your VM instance
+## 6. Experience your VM instance
 
   1. Look at the last output of `orka3 vm list` again. Get that IP and `Screenshare` port.
   2. Launch Apple Screen Sharing on your local machine (`Cmd+K` in Finder). Type `vnc://<VM-IP>:<Screenshare-port>`.
@@ -239,9 +239,9 @@ The good news is that `ghcr.io/macstadium/orka-images/sonoma:latest` is already 
   5. (Optional) Launch the Terminal and run the following command.
 
 
-    
-    
-```
+
+
+```bash
 brew install orka-vm-tools OR brew upgrade orka-vm-tools
 ```
 This action ensures that your VM is running the latest version of the [Orka VM Tools](/orka/orka-resources/vm-tools). This collection of services lets Orka manage the guest operating system on Apple silicon-based VMs more efficiently and enables key features, such as [shared VM storage](/orka/orka-resources/shared-vm-storage).
@@ -252,7 +252,7 @@ If your cluster and CLI are not running the latest Orka version, download and in
 
 
 
-## 7\. Preserve the image changes
+## 7. Preserve the image changes
 
 Changing a running VM's configuration or file system does not affect its base image. As soon as you delete the VM, your changes will be lost, and you will need to recreate them manually on other VMs.
 
@@ -287,9 +287,9 @@ To create changes that stick and appear on future deployments, you can commit yo
 This operation will retain the new admin password and the latest OS updates. You might need to share the new admin password with future users who follow this guide.
 
 Return to the command line on your local machine and run:
-    
-    
-```
+
+
+```bash
 orka3 vm commit <VM_NAME>
 
 OR
@@ -308,16 +308,16 @@ Registry credentials are required to push an image. For more information, run `o
   2. See how the changes are preserved for yourself. Deploy a new VM instance:
 
 
-    
-    
-```
+
+
+```bash
 orka3 vm deploy --image <IMAGE_NAME>
 ```
   3. Launch Apple Screen Sharing and connect to the newly deployed VM instance. Use the updated admin credentials to log in.
 
 
 
-## 8\. Delete VMs
+## 8. Delete VMs
 
 _This section is optional._
 
@@ -326,16 +326,21 @@ When your VM instances have served their purpose, you can `delete` them.
   1. Remove all VM instances you created until now:
 
 
-    
-    
-```
+
+
+```bash
 orka3 vm delete <VM_NAME>
 ```
   2. List your VMs again.
 
-
-    
-    
-```
+```bash
 orka3 vm list
 ```
+
+## Next steps
+
+Now that you've deployed and managed your first VM, you're ready to integrate Orka with your CI/CD pipeline:
+
+- [CI/CD Integrations Quick Start](/orka/quick-start-guides/cicd-integrations-quick-start) — set up a service account, create a VM template, and connect Orka to your build system
+- [Orka VM Tools](/orka/orka-resources/vm-tools) — install Orka VM Tools on Apple Silicon VMs to enable shared storage and other features
+- [Tools and Integrations](/orka/orka-overview/tools-integrations) — browse all available Orka CLI versions and CI/CD integrations

--- a/orka/quick-start-guides/web-ui-quick-start.mdx
+++ b/orka/quick-start-guides/web-ui-quick-start.mdx
@@ -42,7 +42,7 @@ The Orka UI will be most beneficial to:
 
 
 
-## 1\. Before you begin
+## 1. Before you begin
 
   1. Ensure you can access your cluster account in the MacStadium Customer Portal. See [Cluster Access Management: Overview](/orka/orka-cluster-access/cluster-access-management-overview).
   2. Get your VPN connection information from your IP Plan. You can [download](/macstadium/macstadium-overview/ip-plan) it from the [MacStadium portal](https://portal.macstadium.com/).
@@ -52,7 +52,7 @@ The Orka UI will be most beneficial to:
 
 
 
-## 2\. Authenticate with the cluster
+## 2. Authenticate with the cluster
 
 Orka lets you log in with your MacStadium Customer Portal credentials. Your access privileges are based on the role configured by your account admin in the Customer Portal. By default, you will have access to the `orka-default` namespace. You can access additional namespaces if you have been added to additional role bindings.
 
@@ -61,20 +61,20 @@ Orka lets you log in with your MacStadium Customer Portal credentials. Your acce
 > A way to isolate and dedicate resources to users and teams within the cluster.
 > 
 > The resources within a namespace are completely isolated from one another and cannot be shared between namespaces. By default, users and service accounts limited to a specific namespace cannot access the resources in other namespaces, unless added to the respective role bindings.
-    
-    
-```
+
+
+```bash
 orka3 login
 ```
 Orka will launch a new browser tab (or window) and let you log in via the SSO-enabled form. After you log in, you can return to the command line and run additional `orka3` commands. Your token is stored locally in the `~/.kube/config` file. Note that your token has a validity duration of one hour. Afterward, you must obtain and pass a new token in your CLI or API calls.
 
 You now need to get your Orka authentication token from your `~/.kube/config`:
-    
-    
-```
+
+
+```bash
 orka3 user get-token
 ```
-## 3\. Launch the Orka UI
+## 3. Launch the Orka UI
 
   * In your browser, navigate to your Orka API URL.
 
@@ -94,7 +94,7 @@ orka3 user get-token
 
 ![f3f5e8d-Screenshot_2023-10-10_at_23.37.22.png](/images/attachments/28393224419867.png)
 
-## 4\. Create and deploy your first VM instance
+## 4. Create and deploy your first VM instance
 
 > #### **Known limitations**
 > 
@@ -193,7 +193,7 @@ Note: this screen shows essential and detailed connection information about your
 
 
 
-## 5\. Experience your VM instance
+## 5. Experience your VM instance
 
   1. Return to the **VMs** page and click the **Connection** button for your VM.
 
@@ -222,13 +222,13 @@ The good news is that `sonoma-90gb-orka3-arm` is already preconfigured for you, 
   5. (Optional) Launch the Terminal application and run the following command.
 
 
-    
-    
-```
-brew install orka-vm-tools  
-  
-OR  
-  
+
+
+```bash
+brew install orka-vm-tools
+
+OR
+
 brew upgrade orka-vm-tools
 ```
 This action ensures that your VM (Virtual Machine) is running the latest version of the [Orka VM Tools](/orka/orka-resources/vm-tools). This collection of services lets Orka manage the guest operating system on Apple silicon-based VMs (Virtual Machines) more efficiently and enables vital features, such as [shared VM storage](/orka/orka-resources/shared-vm-storage).
@@ -239,7 +239,7 @@ If your cluster is not running the latest Orka version, download and install an 
 
 
 
-## 6\. Create a new base image
+## 6. Create a new base image
 
 Changing the configuration or the file system of a running VM (Virtual Machine) does not affect its base image. As soon as you delete the VM (Virtual Machine), your changes will be lost; in other words, they are ephemeral, and you will need to recreate them manually on other VMs (Virtual Machines).
 
@@ -273,7 +273,7 @@ Wait for the operation to complete. It might take a while. There is no progress 
 > 
 > To use your newly created image, you need to create a new VM config.
 
-## 7\. Delete VMs
+## 7. Delete VMs
 
  _This section is optional._
 
@@ -292,3 +292,9 @@ When your VM configs and instances have served their purpose, you can remove the
 When the page refreshes, you should not see any more VM instances. Your VM config is still available on the **VM Configs** page, and you can deploy new instances from it.
 
 Note that the changes you made to your deleted VM instance will not be present on newly deployed instances.
+
+## Next steps
+
+- [CI/CD Integrations Quick Start](/orka/quick-start-guides/cicd-integrations-quick-start) — automate VM deployment in your build pipeline
+- [Orka VM Tools](/orka/orka-resources/vm-tools) — enable shared storage and additional features on Apple Silicon VMs
+- [Tools and Integrations](/orka/orka-overview/tools-integrations) — browse available integrations


### PR DESCRIPTION
Pre-launch quality pass across quick start guides and key overview pages.

## Changes

**Code blocks**
- Added `bash` language tags to ~35 bare code fences across all 4 quick start guides — syntax highlighting was missing on every CLI and cURL example

**Callouts**
- Converted `PLEASE NOTE: Your Service Account Tokens will need to be regenerated` (buried in table cells in orka-upgrades) to prominent `<Warning>` callouts — this is safety-critical info that was easy to miss
- Converted emoji blockquotes (`🗒️NOTE`, `📘`, `👍`) to proper Mintlify `<Note>` components in orka-overview and support pages

**Headings**
- Fixed escaped numbered headings (`## 1\.` → `## 1.`) across quick starts and orka-overview — Zendesk migration artifact

**Navigation**
- Added "Next steps" section to all 4 quick start guides (CLI, Web UI, CI/CD, API) — pages previously ended abruptly with no link forward

**Misc**
- Fixed `AUthorize` typo in API quick start
- Fixed escaped URL `\<http://status.macstadium.com/>` in support page

🤖 Generated with [Claude Code](https://claude.com/claude-code)