### PR TITLE
Fix API quick start code blocks and stale version references

### DIFF
--- a/orka/compatibility/feature-parity-apple-hardware.mdx
+++ b/orka/compatibility/feature-parity-apple-hardware.mdx
@@ -191,7 +191,7 @@ macOS 12 (Monterey) | ✅ | ❌*
 macOS 13 (Ventura) | ✅ | ✅  
 macOS 14 (Sonoma) | ✅ | ✅  
   
-* Starting with Orka 2.4.0, shared VM storage is deprecated for Apple silicon-based VMs running macOS Monterey. In Orka 3.0.0, shared VM storage will be removed for all Apple Silicon-based Monterey VMs.
+* Starting with Orka 2.4.0, shared VM storage was deprecated for Apple silicon-based VMs running macOS Monterey. In Orka 3.0.0, shared VM storage was removed for all Apple Silicon-based Monterey VMs.
 
 ## VMs: Networking
 

--- a/orka/orka-desktop/welcome-to-orka-desktop-30.mdx
+++ b/orka/orka-desktop/welcome-to-orka-desktop-30.mdx
@@ -22,15 +22,13 @@ suggested_new_path: "/orka/orka-desktop/welcome-to-orka-desktop-30"
 > 
 > Users can publish any image to a container registry, for example, GitHub Packages or DockerHub and then pull it into the **Orka Cluster**.
 
-> 📘 **Downloading Orka Desktop**
-> 
-> Orka Desktop is available from the following locations:
-> 
-> *MacStadium website: \<https://www.macstadium.com/>
-> 
-> *MacStadium GitHib repo: \<https://github.com/macstadium/orka-desktop/releases>
-> 
-> *Brew package manager: Coming Soon
+<Note>
+  Orka Desktop is available from the following locations:
+
+  - MacStadium website: [macstadium.com](https://www.macstadium.com/)
+  - GitHub releases: [macstadium/orka-desktop](https://github.com/macstadium/orka-desktop/releases)
+  - Homebrew: `brew install orka-desktop`
+</Note>
 
 > 📘 **Orka Desktop Requirements**
 > 

--- a/orka/orka-resources/apple-silicon-based-support.mdx
+++ b/orka/orka-resources/apple-silicon-based-support.mdx
@@ -113,7 +113,7 @@ Below is a list of the ones that are not applicable to Apple silicon-based VMs:
 
   4. VM revert is not supported due to limitations of the Apple Virtualization Framework.
 
-  5. Starting with Orka 2.4.0, shared VM storage is **deprecated** for Apple silicon-based VMs running macOS Monterey and **will be removed** in Orka 2.5.0. To continue using shared VM storage with Orka 2.5.0 and later, you will need to upgrade your Apple Silicon-based Monterey VMs to macOS Ventura, OR switch to Intel-based Monterey VMs.
+  5. Starting with Orka 2.4.0, shared VM storage was **deprecated** for Apple silicon-based VMs running macOS Monterey and was **removed** in Orka 2.5.0. To use shared VM storage on Orka 2.5.0 and later, upgrade your Apple Silicon-based Monterey VMs to macOS Ventura, or switch to Intel-based Monterey VMs.
 
   6. After you resize an Apple silicon-based VM and attempt to upgrade to a newer macOS version, the upgrade might fail or you might experience other issues with your VM. This is a limitation of the Apple Virtualization framework and applies to all macOS versions.
 **Workaround:** Upgrade the macOS image before resizing. If you have already resized, deploy a fresh VM from an unresized image and upgrade from there.

--- a/orka/quick-start-guides/orka3-api-quick-start.mdx
+++ b/orka/quick-start-guides/orka3-api-quick-start.mdx
@@ -117,43 +117,46 @@ curl -X 'GET' \
 '<ORKA_API_URL>/api/v1/namespaces/orka-default/nodes' \
 -H 'accept: application/json' \
 -H 'Authorization: Bearer <TOKEN>'
-
+```
 
 **Response**
+
+```json
 {
-"items": [
-{
-"name": "macpro-4",  
-"namespace": "orka-default",  
-"nodeIP": "10.221.189.11",  
-"availableCpu": 12,  
-"availableMemory": "31.23G",  
-"availableGpu": 0,  
-"allocatableCpu": 12,  
-"allocatableMemory": "31.23G",  
-"allocatableGpu": 0,  
-"nodeType": "WORKER",  
-"phase": "READY",  
-"orkaTags": []  
-},  
-{  
-"name": "mini-arm-13",  
-"namespace": "orka-default",  
-"nodeIP": "10.221.189.13",  
-"availableCpu": 5,  
-"availableMemory": "11.20G",  
-"availableGpu": 0,  
-"allocatableCpu": 8,  
-"allocatableMemory": "16.00G",  
-"allocatableGpu": 0,  
-"nodeType": "WORKER",  
-"phase": "READY",  
-"orkaTags": []  
-}  
-]  
-}  
-This API call provides an overview of your nodes. It shows the actual IP, the state, and the available resources on each node.
+  "items": [
+    {
+      "name": "macpro-4",
+      "namespace": "orka-default",
+      "nodeIP": "10.221.189.11",
+      "availableCpu": 12,
+      "availableMemory": "31.23G",
+      "availableGpu": 0,
+      "allocatableCpu": 12,
+      "allocatableMemory": "31.23G",
+      "allocatableGpu": 0,
+      "nodeType": "WORKER",
+      "phase": "READY",
+      "orkaTags": []
+    },
+    {
+      "name": "mini-arm-13",
+      "namespace": "orka-default",
+      "nodeIP": "10.221.189.13",
+      "availableCpu": 5,
+      "availableMemory": "11.20G",
+      "availableGpu": 0,
+      "allocatableCpu": 8,
+      "allocatableMemory": "16.00G",
+      "allocatableGpu": 0,
+      "nodeType": "WORKER",
+      "phase": "READY",
+      "orkaTags": []
+    }
+  ]
+}
 ```
+
+This API call provides an overview of your nodes. It shows the actual IP, the state, and the available resources on each node.
 **Glossary: Node**
 
 A genuine Apple physical host that provides computational resources (RAM and CPU) for your workloads.
@@ -180,9 +183,9 @@ curl -X 'GET' \
 ```
 **Response**
 
-```bash
+```json
 {
-"items": []
+  "items": []
 }
 ```
 This API call lists all VM instances in the `orka-default` namespace. If nothing prints, no one has created any VM instances yet.
@@ -219,20 +222,22 @@ curl -X 'POST' \
 -H 'Authorization: Bearer <TOKEN>' \
 -H 'Content-Type: application/json' \
 -d '{
-"image": "sonoma-90gb-orka3-arm"
+  "image": "sonoma-90gb-orka3-arm"
 }'
-
+```
 
 **Response**
+
+```json
 {
-"name": "vm-cznfv",
-"node": "mini-arm-13",
-"memory": "4.80Gi",
-"ip": "10.221.189.13",
-"ssh": 8822,
-"vnc": 5999,
-"screenshare": 5901,
-"status": "Running"
+  "name": "vm-cznfv",
+  "node": "mini-arm-13",
+  "memory": "4.80Gi",
+  "ip": "10.221.189.13",
+  "ssh": 8822,
+  "vnc": 5999,
+  "screenshare": 5901,
+  "status": "Running"
 }
 ```
 The bare minimum required argument is `image`.
@@ -257,16 +262,16 @@ curl -X 'POST' \
 ```
 **Response**
 
-```bash
+```json
 {
-"name": "vm-cznfv",
-"node": "mini-arm-13",
-"memory": "4.80Gi",
-"ip": "10.221.189.13",
-"ssh": 8822,
-"vnc": 5999,
-"screenshare": 5901,
-"status": "Running"
+  "name": "vm-cznfv",
+  "node": "mini-arm-13",
+  "memory": "4.80Gi",
+  "ip": "10.221.189.13",
+  "ssh": 8822,
+  "vnc": 5999,
+  "screenshare": 5901,
+  "status": "Running"
 }
 ```
   5. What happens if you list your VMs again now?
@@ -283,24 +288,24 @@ curl -X 'GET' \
 ```
 **Response**
 
-```bash
+```json
 {
-"items": [
-{
-"name": "vm-l4qgb",  
-"ip": "10.221.189.13",  
-"cpu": 3,  
-"deployDate": "2023-10-10T19:56:21Z",  
-"image": "sonoma-90gb-orka3-arm",  
-"gpuPassthrough": false,  
-"memory": "4.80Gi",  
-"node": "mini-arm-13",  
-"screenshare": 5901,  
-"ssh": 8822,  
-"status": "Running",  
-"vnc": 5999  
-}  
-]  
+  "items": [
+    {
+      "name": "vm-l4qgb",
+      "ip": "10.221.189.13",
+      "cpu": 3,
+      "deployDate": "2023-10-10T19:56:21Z",
+      "image": "sonoma-90gb-orka3-arm",
+      "gpuPassthrough": false,
+      "memory": "4.80Gi",
+      "node": "mini-arm-13",
+      "screenshare": 5901,
+      "ssh": 8822,
+      "status": "Running",
+      "vnc": 5999
+    }
+  ]
 }
 ```
 The API now returns information about your running VM.
@@ -353,10 +358,10 @@ If you're using another image as your starting point or if you are installing yo
 
 
 ```bash
+# First time
 brew install orka-vm-tools
 
-OR
-
+# If already installed
 brew upgrade orka-vm-tools
 ```
 This action ensures that your VM is running the latest version of the [Orka VM Tools](/orka/orka-resources/vm-tools). This collection of services lets Orka manage the guest operating system on Apple silicon-based VMs more efficiently and enables vital features, such as [shared VM storage](/orka/orka-resources/shared-vm-storage).
@@ -425,17 +430,19 @@ curl -X 'POST' \
 "imageReference": "<REGISTRY>/<IMAGE>:<TAG>"
 }'
 ```
-**Response**
+**Response** (commit or save)
 
-```bash
+```json
 {
-"statusUrl": "/api/v1/namespaces/orka-default/images/sonoma-90gb-orka3-arm"
+  "statusUrl": "/api/v1/namespaces/orka-default/images/sonoma-90gb-orka3-arm"
 }
+```
 
-OR
+**Response** (push)
 
+```json
 {
-"jobName": "<PUSH_JOB_ID>"
+  "jobName": "<PUSH_JOB_ID>"
 }
 ```
   2. See how the changes are preserved for yourself. Deploy a new VM instance from your image:


### PR DESCRIPTION
## Summary

- **API quick start code blocks**: The GET /nodes example had an unclosed code fence — the curl command, `**Response**` label, JSON payload, and explanatory text were all trapped in one `bash` block. Split into proper `bash` (curl) + `json` (response) blocks throughout the file. Also fixed the POST /vms example with the same issue, corrected all JSON response blocks from `bash` → `json`, and split `OR`-separated multi-command blocks into discrete examples with comments.
- **Orka Desktop "Coming Soon: Brew"**: Removed the stale note — `brew install orka-desktop` is already documented and working in the same file. Converted the emoji blockquote to a `<Note>` component while at it.
- **Stale shared VM storage references**: Updated future-tense language ("will be removed") to past tense in `apple-silicon-based-support.mdx` and `feature-parity-apple-hardware.mdx` — this removal shipped in Orka 2.5.0 / 3.0.0.

Closes #32

## Test plan
- [x] Verify API quick start renders all code blocks correctly (no giant fused blocks, proper JSON syntax highlighting)
- [x] Verify Orka Desktop page no longer shows "Coming Soon: Brew"
- [x] Verify shared VM storage removal language reads as past tense

🤖 Generated with [Claude Code](https://claude.com/claude-code)