### PR TITLE
Fix heading artifact and typo from QA feedback

### DIFF
--- a/orka/orka-engine/orka-engine-30.mdx
+++ b/orka/orka-engine/orka-engine-30.mdx
@@ -199,11 +199,14 @@ Stop a headless VM or VM with a display console enter **ctrl-c**(from the termin
 
 MacStadium hosts a number of Sequoia, Sonoma, and Ventura images on [GitHub - macstadium/orka-images: Public images for Apple silicon-based Orka virtual machines](https://github.com/macstadium/orka-images/) In `orka-engine vm ,` specify an `--image` option to be the URL of an image coming from an OCI registry, 
 
-`orka-engine vm run sonoma-latest --image ghcr.io/macstadium/orka-images/sonoma:latest`
+```bash
+orka-engine vm run sonoma-latest --image ghcr.io/macstadium/orka-images/sonoma:latest
+```
 
-`Starting VM sonoma-latest with MAC address f6:59:c1:15:5e:cb`  
----  
-  
+```
+Starting VM sonoma-latest with MAC address f6:59:c1:15:5e:cb
+```
+
   1. Once the GUI starts up, the credentials are **admin/admin**.
 
   2. Once logged in, the VM is ready for use or additional software and tools installation.

--- a/orka/orka-on-aws-and-on-prem/it-administrator-onboarding-guide.mdx
+++ b/orka/orka-on-aws-and-on-prem/it-administrator-onboarding-guide.mdx
@@ -122,10 +122,9 @@ Day-to-day activities can vary, but will often consist of a mix of provisioning 
   
 ![Orka for VDI architecture diagram](/images/attachments/orka-vdi-architecture.png)
 
-##    
-Getting Started
+## Getting Started
 
-### Ansbile access and credentials setup
+### Ansible access and credentials setup
 
 You will want to verify that you have access to all three Orka for VDI management layers.
 


### PR DESCRIPTION
## Summary

Fixes two formatting issues flagged during internal QA:

- **orka-engine-30**: bare `---` after an inline code line was rendering as a Setext-style `<h2>` heading. Moved command and output into proper fenced code blocks.
- **it-administrator-onboarding-guide**: `## ` heading split across two lines was rendering as broken heading; also fixed "Ansbile" typo.

Benchmarks table (`macstadium-bare-metal-mac-benchmarks`) is tracked separately — the table structure needs reformatting but the underlying numbers need human verification before touching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)