### PR TITLE
Fix table formatting in benchmarks

### DIFF
--- a/iaas/bare-metal-macs/macstadium-bare-metal-mac-benchmarks.mdx
+++ b/iaas/bare-metal-macs/macstadium-bare-metal-mac-benchmarks.mdx
@@ -66,80 +66,18 @@ This table includes Standard models currently available as Bare Metal from MacSt
 
 This table includes the full range of benchmarked hardware, including several machines not currently available for reference. Current and former MacStadium standard bare metal machines will have their name listed.
 
-Name | Type | CPU | GPU | RAM | SSD | Xcode  
-Benchmark | Geekbench CPU | Geekbench GPU | Cinebench  
----|---|---|---|---|---|---|---|---|---  
-S2.M | Mac Studio | 24C  
-M2 Ultra | 60C | 64GB | 2TB | 53.599s  
-(2.31x) | 20963  
-(2.38x) | 206071  
-(6.09x) | 28945  
-(3.68x)  
-S1.L | Mac Studio | 20C  
-M1 Ultra | 64C | 128GB | 4TB | 65.558s  
-(1.89x) | 18060  
-(2.05x) | 174505  
-(5.16x) | 224214  
-(3.08x)  
-N/A | Mac Studio | 12C  
-M2 Max | 30C | 32GB | 512G | 74.003s  
-(1.67x) | 14872  
-(1.69x) | 127390  
-(3.76x) | 14885  
-(1.89x)  
-M2.XL | Mac mini | 12C M2 Pro | 19C | 32GB | 2TB | 74.659s  
-(1.64x) | 14686  
-(1.67x) | 81837  
-(2.42x) | 14812  
-(1.88x)  
-S1.M | Mac Studio | 10C  
-M1 Max | 32C | 64GB | 2TB | 89.340  
-(1.39x) | 12947  
-(1.47x) | 119490  
-(3.53x) | 12457  
-(1.58x)  
-M2.L | Mac mini | 10C M2 Pro | 16C | 16GB | 1TB | 84.904s  
-(1.46x) | 12405  
-(1.41x) | 73622  
-(2.18x) | 11858  
-(1.51x)  
-M2.M | Mac mini | 8C M2 | 10C | 16GB | 1TB | 106.259s  
-(1.17x) | 10130  
-(1.15x) | 45902  
-(1.36x) | 8776  
-(1.12x)  
-M2.S | Mac mini | 8C M2 | 10C | 8GB | 256GB | 108.477s (1.14x) | 10192 (1.16x) | 45891 (1.36x) | 8780  
-(1.12x)  
-M1.M | Mac mini | 8C M1 | 8C | 16GB | 1TB | 123.885s  
-(1.00x) | 8818  
-(1.00x) | 33843  
-(1.00x) | 7869  
-(1.00x)  
-G4B | Mac mini  
-(2018) | 6C  
-i7 3.2 |  | 32G | 512GB | 188.779s  
-(0.66x) | 6754  
-(0.77x) | 6631  
-(0.20x) | 7645  
-(0.97x)  
-G2 | Mac Pro (2013) (12.6.7) | 12C  
-Xeon | Dual D500 | 64GB | 1TB | 193.603s  
-(0.73x) | 5311  
-(0.60x) | 24788  
-(0.73x) | 8507  
-(1.08x)  
-G2 | Mac Pro  
-(2013)  
-(12.6.7) | 6C  
-Xeon | Dual D500 | 32GB | 1TB | 264.804s  
-(0.47x) | 3862  
-(0.44x) | 24887  
-(0.74x) | 3862  
-(0.49x)  
-G4A | Mac mini  
-(2018) | 4C  
-i3 3.6 |  | 16GB | 512GB | 369.022s  
-(0.36x) | 3912  
-(0.44x) | 5806  
-(0.17x) | 3606  
-(0.46x)
+| Name | Type | CPU | GPU | RAM | SSD | Xcode Benchmark | Geekbench CPU | Geekbench GPU | Cinebench |
+|---|---|---|---|---|---|---|---|---|---|
+| S2.M | Mac Studio | 24C M2 Ultra | 60C | 64GB | 2TB | 53.599s (2.31x) | 20963 (2.38x) | 206071 (6.09x) | 28945 (3.68x) |
+| S1.L | Mac Studio | 20C M1 Ultra | 64C | 128GB | 4TB | 65.558s (1.89x) | 18060 (2.05x) | 174505 (5.16x) | 224214 (3.08x) |
+| N/A | Mac Studio | 12C M2 Max | 30C | 32GB | 512G | 74.003s (1.67x) | 14872 (1.69x) | 127390 (3.76x) | 14885 (1.89x) |
+| M2.XL | Mac mini | 12C M2 Pro | 19C | 32GB | 2TB | 74.659s (1.64x) | 14686 (1.67x) | 81837 (2.42x) | 14812 (1.88x) |
+| S1.M | Mac Studio | 10C M1 Max | 32C | 64GB | 2TB | 89.340 (1.39x) | 12947 (1.47x) | 119490 (3.53x) | 12457 (1.58x) |
+| M2.L | Mac mini | 10C M2 Pro | 16C | 16GB | 1TB | 84.904s (1.46x) | 12405 (1.41x) | 73622 (2.18x) | 11858 (1.51x) |
+| M2.M | Mac mini | 8C M2 | 10C | 16GB | 1TB | 106.259s (1.17x) | 10130 (1.15x) | 45902 (1.36x) | 8776 (1.12x) |
+| M2.S | Mac mini | 8C M2 | 10C | 8GB | 256GB | 108.477s (1.14x) | 10192 (1.16x) | 45891 (1.36x) | 8780 (1.12x) |
+| M1.M | Mac mini | 8C M1 | 8C | 16GB | 1TB | 123.885s (1.00x) | 8818 (1.00x) | 33843 (1.00x) | 7869 (1.00x) |
+| G4B | Mac mini (2018) | 6C i7 3.2 |  | 32G | 512GB | 188.779s (0.66x) | 6754 (0.77x) | 6631 (0.20x) | 7645 (0.97x) |
+| G2 | Mac Pro (2013) (12.6.7) | 12C Xeon | Dual D500 | 64GB | 1TB | 193.603s (0.73x) | 5311 (0.60x) | 24788 (0.73x) | 8507 (1.08x) |
+| G2 | Mac Pro (2013) (12.6.7) | 6C Xeon | Dual D500 | 32GB | 1TB | 264.804s (0.47x) | 3862 (0.44x) | 24887 (0.74x) | 3862 (0.49x) |
+| G4A | Mac mini (2018) | 4C i3 3.6 |  | 16GB | 512GB | 369.022s (0.36x) | 3912 (0.44x) | 5806 (0.17x) | 3606 (0.46x) |


### PR DESCRIPTION
Fixed Markdown table formatting in the bare metal Mac benchmarks documentation. All three tables (Benchmarking Baseline, Current Standard Models, and Full Results) now use proper pipe-delimited syntax with consistent formatting.

## Files changed
- `iaas/bare-metal-macs/macstadium-bare-metal-mac-benchmarks.mdx`