### PR TITLE
Add GSC verification meta tag; remove HTML verification file

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -471,6 +471,13 @@
       }
     ]
   },
+  "seo": {
+    "metatags": {
+      "name": {
+        "google-site-verification": "e4fa3fa1d2f50212"
+      }
+    }
+  },
   "redirects": [
     { "source": "/docs", "destination": "/" },
     { "source": "/docs/support", "destination": "https://support.macstadium.com" },

--- a/googlee4fa3fa1d2f50212.html
+++ b/googlee4fa3fa1d2f50212.html
@@ -1,1 +1,0 @@
-google-site-verification: googlee4fa3fa1d2f50212.html


### PR DESCRIPTION
## Summary
- Adds `google-site-verification` meta tag to `docs.json` via the `seo.metatags` config — this is how Mintlify handles GSC verification (the HTML file method doesn't work since Mintlify doesn't serve arbitrary files from the repo root)
- Deletes `googlee4fa3fa1d2f50212.html` which was sitting in the repo unused

## After merging
Once deployed, verify ownership in Google Search Console using the HTML tag method, then submit `https://docs.macstadium.com/sitemap.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)