### PR TITLE
Content clarity: 2FA, SAML, VM Tools, Shared Storage

### DIFF
--- a/macstadium/account-management-and-saml/saml-sso.mdx
+++ b/macstadium/account-management-and-saml/saml-sso.mdx
@@ -22,7 +22,7 @@ The MacStadium SAML Single Sign-On (SSO) integration provides a secure and seaml
 
 
 
-SAML SSO is a paid offering. Please contact your account team through the portal for more information.
+<Note>SAML SSO is a paid offering. Contact your account team through the [portal](https://portal.macstadium.com) for more information.</Note>
 
 ## Key Components
 
@@ -37,7 +37,7 @@ The MacStadium SAML SSO integration involves these key components:
 
 ## How it works
 
-  1. **Configuration** : Your IdP Admin will configure your IdP to integrate with MacStadium and provide some metadata to our support staff to complete the integration. Refer to our detailed docs for steps
+  1. **Configuration** : Your IdP Admin will configure your IdP to integrate with MacStadium and provide some metadata to our support staff to complete the integration. See the setup guides under Next Steps below.
   2. **User Login** : A user attempts to access MacStadium resources.
   3. **Redirection** : The MacStadium Portal redirects users to your IdP's login page.
   4. **Authentication** : The user provides their credentials to your IdP.
@@ -58,4 +58,8 @@ The MacStadium SAML SSO integration works seamlessly with major identity provide
 
 ## Next steps
 
-Refer to our setup guide for step-by-step instructions on configuring the SAML integration with your chosen IdP.
+Select your identity provider for step-by-step setup instructions:
+
+- [Enable SAML SSO with Okta](/macstadium/account-management-and-saml/enable-saml-sso-with-okta)
+- [Enable SAML SSO with Azure Active Directory](/macstadium/account-management-and-saml/enable-saml-sso-with-azure-active-directory)
+- [Enable SAML SSO with Google Workspace](/macstadium/account-management-and-saml/enable-saml-sso-with-google-workspace-federation)

--- a/macstadium/account-management-and-saml/two-factor-authentication-2fa.mdx
+++ b/macstadium/account-management-and-saml/two-factor-authentication-2fa.mdx
@@ -20,13 +20,13 @@ MacStadium offers the ability for customers to enable two-factor authentication 
 
 Two-factor authentication is available for anyone with Portal access. 
 
-📘 2FA is NOT turned on by default. It is not required to logon to [portal.macstadium.com](https://portal.macstadium.com). It can easily be turned on/off from inside the Customer Portal.
+<Note>2FA is NOT turned on by default. It is not required to log in to [portal.macstadium.com](https://portal.macstadium.com). It can easily be turned on/off from inside the Customer Portal.</Note>
 
 ## Getting Started
 
 You must have an account in [portal.macstadium.com](https://portal.macstadium.com) to use two-factor authentication.
 
-📘 If there is no account in the Customer Portal, then request one from an existing account administrator within the organization. For any questions about the Customer Portal, send an email to [support@macstadium.com](mailto:support@macstadium.com).
+<Note>If there is no account in the Customer Portal, request one from an existing account administrator within your organization. For questions, email [support@macstadium.com](mailto:support@macstadium.com).</Note>
 
 **Enabling Two-Factor Authentication:**
 
@@ -40,16 +40,18 @@ You must have an account in [portal.macstadium.com](https://portal.macstadium.co
 
 
 
-👍 An authenticator app can be downloaded from the Apple App Store or Google Play.
+<Tip>An authenticator app can be downloaded from the Apple App Store or Google Play.</Tip>
 
 8. Enter the corresponding code provided by your authenticator app.
 
 9. Two-factor authentication now changes to **Active** in the _Security_ tab of the Portal.
 
-📘 On the next login, the screen looks different after signing in with the _username_ and _password_.
+## First Login After Enabling 2FA
 
-  1. Once authenticated, the screen prompts ask for the authenticator app.
-  2. The authenticator app sends a 6-digit code.
+On the next login, the sign-in screen looks different after entering your username and password:
+
+  1. Once authenticated, you are prompted to open your authenticator app.
+  2. The authenticator app provides a 6-digit code.
   3. Enter the 6-digit code to gain access.
 
 
@@ -58,9 +60,9 @@ You must have an account in [portal.macstadium.com](https://portal.macstadium.co
 
 The Mandatory Two-Factor Authentication (2FA) Enforcement feature empowers administrators to enhance the security of user accounts by enforcing compulsory 2FA for all associated users. By enabling this functionality, administrators ensure an additional layer of protection for sensitive information and transactions within the Customer Portal.
 
-_📘_ This feature is accessible only to team members with Administrator roles. The Mandatory 2FA is disabled by pressing the Disable Mandatory 2FA button.
+<Note>This feature is accessible only to team members with Administrator roles. Mandatory 2FA is disabled by pressing the **Disable Mandatory 2FA** button.</Note>
 
-_📘_ 2FA can be disabled by clicking the **Disable** button in the _Security_ tab.
+<Note>2FA can be disabled by clicking the **Disable** button in the _Security_ tab.</Note>
 
 If there is a need to disable two-factor authentication, but access to the phone that was used to authenticate is missing, then:
 

--- a/orka/orka-resources/shared-vm-storage.mdx
+++ b/orka/orka-resources/shared-vm-storage.mdx
@@ -12,11 +12,12 @@ labels: ["orka", "api", "storage", "shared"]
 suggested_new_path: "/orka/orka-resources/shared-vm-storage"
 ---
 
-#### **Apple Silicon-based Monterey VMs**
-
-Starting with Orka 2.4.0, shared VM storage is deprecated for Apple Silicon-based VMs running macOS Monterey. Intel-based Monterey VMs are not affected.
-
-In [Orka 3.0](/orka/orka-upgrades-and-release-notes/orka-30-release-notes), shared VM storage is enabled for Apple Silicon macOS Ventura and newer.
+| Platform | Status | Notes |
+|---|---|---|
+| Apple Silicon — macOS Monterey | Deprecated as of Orka 2.4.0 | Intel Monterey VMs are not affected |
+| Intel — macOS Monterey | Supported | — |
+| Apple Silicon — macOS Ventura and later | Supported as of [Orka 3.0](/orka/orka-upgrades-and-release-notes/orka-30-release-notes) | Requires Orka VM Tools |
+| Intel — macOS Ventura and later | Supported | — |
 
 ## Overview
 

--- a/orka/orka-resources/vm-tools.mdx
+++ b/orka/orka-resources/vm-tools.mdx
@@ -30,10 +30,14 @@ Make sure to pull the updated sonoma-90gb-orka3-arm image from the remote in ord
 
 [Learn more about pulling an image](/orka/orka3-cli-reference/image-management)
 
-To access the latest features and updates, always run the Orka VM Tools version that matches your cluster and the other Orka tools and integrations you're using. For example: your cluster, Orka tools and integrations, and Orka VM Tools all run 3.x versions.
+<Warning>Always run the Orka VM Tools version that matches your cluster and other Orka tools and integrations. A version mismatch can cause disk resizing and shared storage failures. For example, if your cluster runs 3.x, your Orka VM Tools should also run 3.x.</Warning>
 
 Orka VM Tools run in the background. They are started automatically as a daemon when the operating system starts. You can control Orka VM Tools process using the following commands:
 
-Run sudo launchctl list com.orka.vm.tools to see if Orka VM Tools are running in your VM.
+To check if Orka VM Tools are running in your VM:
+
+```bash
+sudo launchctl list com.orka.vm.tools
+```
 
 ![b037a3d-Screenshot_2022-08-29_at_15.53.04.png](/images/attachments/28340435776027.png)


### PR DESCRIPTION
## Summary
- **2FA**: Converted `📘`/`👍` emoji callouts to proper `<Note>`/`<Tip>` components; added `## First Login After Enabling 2FA` heading to separate the 9-step setup flow from the post-enable login steps
- **SAML SSO**: Converted paid offering note to `<Note>` component; fixed dead-end "Refer to our setup guide" — now links to all three provider-specific guides (Okta, Azure AD, Google Workspace)
- **VM Tools**: Promoted version mismatch note to `<Warning>` callout; wrapped bare `sudo launchctl list` text in a proper code block
- **Shared VM Storage**: Replaced prose compatibility description with a table (Apple Silicon Monterey deprecated / Intel supported / Ventura+ supported)

## Test plan
- [x] 2FA page: callouts render correctly, new heading appears between setup steps and first-login steps
- [x] SAML SSO: Note callout renders, Next Steps links all resolve
- [x] VM Tools: Warning callout renders, code block formats correctly
- [x] Shared VM Storage: table renders with correct column alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)