### PR TITLE
Fix GSC metatag format in docs.json

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -472,11 +472,12 @@
     ]
   },
   "seo": {
-    "metatags": {
-      "name": {
-        "google-site-verification": "e4fa3fa1d2f50212"
+    "metatags": [
+      {
+        "name": "google-site-verification",
+        "content": "e4fa3fa1d2f50212"
       }
-    }
+    ]
   },
   "redirects": [
     { "source": "/docs", "destination": "/" },


### PR DESCRIPTION
## Summary

Fixes deploy failure introduced by #57. Mintlify expects `seo.metatags` as an array of `{name, content}` objects, not a nested object structure.

**Before (broken):**
```json
"seo": {
  "metatags": {
    "name": { "google-site-verification": "e4fa3fa1d2f50212" }
  }
}
```

**After (correct):**
```json
"seo": {
  "metatags": [
    { "name": "google-site-verification", "content": "e4fa3fa1d2f50212" }
  ]
}
```

## Test plan

- [x] Merge and verify Mintlify deployment succeeds
- [ ] Verify `<meta name="google-site-verification" content="e4fa3fa1d2f50212">` appears in page source
- [ ] Complete GSC verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)