### PR TITLE
Fix GSC metatag format

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -472,12 +472,9 @@
     ]
   },
   "seo": {
-    "metatags": [
-      {
-        "name": "google-site-verification",
-        "content": "e4fa3fa1d2f50212"
-      }
-    ]
+    "metatags": {
+      "google-site-verification": "e4fa3fa1d2f50212"
+    }
   },
   "redirects": [
     { "source": "/docs", "destination": "/" },


### PR DESCRIPTION
Mintlify schema requires \`metatags\` as a flat object where keys are tag names and values are strings.

\`\`\`json
"seo": {
  "metatags": {
    "google-site-verification": "e4fa3fa1d2f50212"
  }
}
\`\`\`

Previous attempts failed because: nested object under \`name\` key → array of objects. This is the only remaining format that satisfies both constraints from the error messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)