### PR TITLE
Fix SAML SSO pages: replace emoji callouts, fix Azure AD typo and code block

### DIFF
--- a/macstadium/account-management-and-saml/enable-saml-sso-with-azure-active-directory.mdx
+++ b/macstadium/account-management-and-saml/enable-saml-sso-with-azure-active-directory.mdx
@@ -15,19 +15,15 @@ suggested_new_path: "/macstadium/account-management-and-saml/enable-saml-sso-wit
 
 ## About
 
-SAML SSO is a paid offering.
+<Note>SAML SSO is a paid offering. Contact your account team through the [Customer Portal](https://portal.macstadium.com) for more information.</Note>
 
-📘 Please contact the account team through the Customer Portal for more information.
+<Warning>MacStadium does not support IdP-initiated logins. After SSO is configured, all users must log in at [portal.macstadium.com/sso](https://portal.macstadium.com/sso) using the ID provided by the MacStadium team.</Warning>
 
-👍 Log into the Portal by going to [portal.macstadium.com](https://portal.macstadium.com/login).
-
-⚠️ We do not currently support IdP-initiated logins. After SSO is configured with MacStadium, all users will use the below link to log into your account using an ID that will be provided to you by the MacStadium team.
-
-[portal.macstadium.com/sso](https://portal.macstadium.com/sso)
+<Tip>You can also log in directly at [portal.macstadium.com](https://portal.macstadium.com/login).</Tip>
 
 ## Overview
 
-SAML SSO with Azure AD , allowa customers to:
+SAML SSO with Azure AD allows customers to:
 
   * Enable users to be automatically signed in to MacStadium using their Azure Ad accounts.
   * Manage accounts in one central location – Azure AD.
@@ -52,16 +48,13 @@ SAML SSO with Azure AD , allowa customers to:
 ![529d208-6.png](/images/attachments/28263129266459.png)
   7. Click **Edit** on the _Basic SAML settings._  
 ![6385eeb-7.png](/images/attachments/28263129267739.png)
-  8. Configure SAML (Steps 11 to 15)
-
-```
- * Identifier (Entity ID): `urn:amazon:cognito:sp:us-east-1_pusi8jHs1`
- * Reply URL (Assertion Consumer Service URL): `https://idp.macstadium.com/saml2/idpresponse`
- * Logout URL (Optional): `https://idp.macstadium.com/saml2/logout`
- * **Save**  
-```
+  8. Configure the SAML settings:
+     * **Identifier (Entity ID):** `urn:amazon:cognito:sp:us-east-1_pusi8jHs1`
+     * **Reply URL (Assertion Consumer Service URL):** `https://idp.macstadium.com/saml2/idpresponse`
+     * **Logout URL (Optional):** `https://idp.macstadium.com/saml2/logout`
+     * Click **Save**
 ![37d0f10-8.png](/images/attachments/28263129269275.png)
-  9. **IMPORTANT** : Next, edit the Attributes & Claims for your SAML app. You will need the email field to be mapped to user.mail.  
+  9. Edit **Attributes & Claims** for your SAML app. <Warning>The email field must be mapped to `user.mail` or login will fail.</Warning>  
 ![Email Claim.png](/images/attachments/37939325807643.png)  
 
 

--- a/macstadium/account-management-and-saml/enable-saml-sso-with-google-workspace-federation.mdx
+++ b/macstadium/account-management-and-saml/enable-saml-sso-with-google-workspace-federation.mdx
@@ -13,7 +13,9 @@ suggested_new_path: "/macstadium/account-management-and-saml/enable-saml-sso-wit
 ---
 
 
-SAML SSO is a paid offering. Please contact your account team through the portal for more information.
+<Note>SAML SSO is a paid offering. Contact your account team through the [Customer Portal](https://portal.macstadium.com) for more information.</Note>
+
+<Warning>MacStadium does not support IdP-initiated logins. After SSO is configured, all users must log in at [portal.macstadium.com/sso](https://portal.macstadium.com/sso) using the ID provided by the MacStadium team.</Warning>
 
   1. Go to [Google Admin Console](https://admin.google.com/)
   2. Navigate to “Web and mobile apps” (Apps → Web and mobile apps in the left menu or use [this link](https://admin.google.com/ac/apps/unified))  

--- a/macstadium/account-management-and-saml/enable-saml-sso-with-okta.mdx
+++ b/macstadium/account-management-and-saml/enable-saml-sso-with-okta.mdx
@@ -14,15 +14,11 @@ suggested_new_path: "/macstadium/account-management-and-saml/enable-saml-sso-wit
 
 ## About
 
-SAML SSO is a paid offering.
+<Note>SAML SSO is a paid offering. Contact your account team through the [Customer Portal](https://portal.macstadium.com) for more information.</Note>
 
-📘 Please contact the account team through the Customer Portal for more information.
+<Warning>MacStadium does not support IdP-initiated logins. After SSO is configured, all users must log in at [portal.macstadium.com/sso](https://portal.macstadium.com/sso) using the ID provided by the MacStadium team.</Warning>
 
-👍 Log into the Portal by going to [portal.macstadium.com](https://portal.macstadium.com/login).
-
-⚠️ We do not currently support IdP-initiated logins. After SSO is configured with MacStadium, all users will use the below link to log into your account using an ID that will be provided to you by the MacStadium team.
-
-[portal.macstadium.com/sso](https://portal.macstadium.com/sso)
+<Tip>You can also log in directly at [portal.macstadium.com](https://portal.macstadium.com/login).</Tip>
 
 ## Overview
 


### PR DESCRIPTION
## Summary

All three SAML SSO setup pages had emoji callouts (📘 👍 ⚠️) migrated from Zendesk that don't belong in Mintlify docs.

- **Okta + Azure AD:** Replaced `📘`/`👍`/`⚠️` inline emoji with `<Note>`, `<Tip>`, `<Warning>` components
- **Google Workspace:** Was missing the paid offering note and IdP-initiated login warning entirely — added for consistency with the other two pages
- **Azure AD additional fixes:**
  - "allowa" typo → "allows"
  - Config instructions (Identifier, Reply URL, Logout URL) were wrapped in a code block — converted to a proper indented list
  - `**IMPORTANT**` on step 9 → `<Warning>` component

## Test plan

- [x] Verify all three SAML pages render cleanly with no emoji
- [x] Verify Warning/Note/Tip callouts appear correctly
- [x] Verify Azure AD step 8 config renders as a list, not a code block

🤖 Generated with [Claude Code](https://claude.com/claude-code)