### PR TITLE
Add redirects for legacy 404s from old Mintlify trial site

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -478,6 +478,9 @@
   },
   "redirects": [
     { "source": "/docs", "destination": "/" },
+    { "source": "/getting-started/creating-your-first-node", "destination": "/orka/quick-start-guides/orka3-cli-quick-start" },
+    { "source": "/getting-started/creating-your-first-node/", "destination": "/orka/quick-start-guides/orka3-cli-quick-start" },
+    { "source": "/changelog", "destination": "/orka/orka-upgrades-and-release-notes/orka-35-release-notes" },
     { "source": "/docs/support", "destination": "https://support.macstadium.com" },
     { "source": "/docs/faqs", "destination": "https://support.macstadium.com" },
     { "source": "/docs/bare-metal-hosts", "destination": "/iaas/iaas-overview/infrastructure-as-a-service-iaas" },


### PR DESCRIPTION
25 URLs showing as 404 in GSC — all from the 2022 Mintlify trial site.

- 23 `/docs/*` paths are already handled by the existing catch-all redirect (`/docs/:path*` → `/`). GSC data is stale (last crawled Mar 26–31) and will clear on next crawl.
- `/getting-started/creating-your-first-node/` — no redirect existed. Added → `/orka/quick-start-guides/orka3-cli-quick-start`
- `/changelog` — no redirect existed. Added → `/orka/orka-upgrades-and-release-notes/orka-35-release-notes`
- `/mintlify-assets` — Mintlify internal asset path, not a real page, no action needed.

After merging, use "Mark as fixed" in GSC to trigger re-crawl of the 404 bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)