### PR TITLE
Fix persona-audit batch: command typos, broken links, heading hierarchy, malformed syntax

### DIFF
--- a/iaas/aws/site-to-site-vpn-configuration-with-aws.mdx
+++ b/iaas/aws/site-to-site-vpn-configuration-with-aws.mdx
@@ -118,7 +118,6 @@ This is done from an Amazon VPC to the MacStadium private cloud.
   3. Set up a virtual private gateway.
   4. Create the Site-To-Site VPN connection.
   5. Ensure that AWS allows inbound traffic.
-  6. Log in to the WS Management Console and access the VPC service.
 
 
 
@@ -135,7 +134,7 @@ For more information about the customer gateway, see Amazon VPC Documentation: C
   2. Click Create Customer Gateway.
   3. Provide a Name. Set a name that is easy to remember.
   4. In BGP ASN, use a private ASN in the range of 64,512–65,534. This is used later as the BGP process number in the MacStadium firewall.
-  5. In the IP Address text box, provide the IP address of the public network listed in Appendix B of the IP IP Plan ( ). By default, this is the FW1-Outside network.
+  5. In the IP Address text box, provide the IP address of the public network listed in Appendix B of the IP Plan. By default, this is the FW1-Outside network.
   6. Keep the other options with the default values and click Create Customer Gateway.
 
 
@@ -174,7 +173,7 @@ If the customer gateway and a virtual private gateway are in place, then configu
 During setup, choose the customer gateway and the virtual private gateway to use, and configure that routing.
 
 <Note>
-Route traffic to the internal, private network. By default, this is the Private-1 network. The networking information for this network in Appendix B of the IP Plan.
+Route traffic to the internal, private network. By default, this is the Private-1 network. The networking information for this network is in Appendix A of the IP Plan.
 </Note>
 
   1. In the VPC service sidebar, locate the Virtual Private Network menu and select Site-To-Site VPN Connections.
@@ -292,7 +291,7 @@ By default, this is the Private-1 network. | [The IP Plan](/macstadium/macstadiu
   1. Verify the configuration file from the AWS Management Console.
   2. Open the configuration file.
   3. Replace all placeholders with their respective values. Use Configuration parameters for reference.
-  4. Uncomment the line: `access-list amzn-filter extended permit ip<.code> to `uncomment, remove !` at the start of the line. </.code>`
+  4. Uncomment the line: `access-list amzn-filter extended permit ip` — to uncomment, remove `!` at the start of the line.
   5. Uncomment the lines for object and nat configuration at the end of the config file. 
      * To uncomment, remove ! at the start of the line.
      * Keep the following line to ensure the SLA monitor works as expected. 

--- a/orka/orka-devops-integrations/drone.mdx
+++ b/orka/orka-devops-integrations/drone.mdx
@@ -2,7 +2,7 @@
 title: "Drone"
 description: "Integrate Drone CI with Orka to run macOS and iOS build pipelines on genuine Apple hardware. Covers ephemeral VM engines, pipeline setup, and configuration."
 zendesk_id: 28398573475867
-zendesk_url: "https://support.macstadium.com/hc/en-us/articles/28398573475867"
+zendesk_url: "/orka/orka-devops-integrations/drone"
 section: "Orka DevOps Integrations"
 category: "Orka"
 ---

--- a/orka/orka-on-aws-and-on-prem/it-administrator-onboarding-guide.mdx
+++ b/orka/orka-on-aws-and-on-prem/it-administrator-onboarding-guide.mdx
@@ -12,7 +12,7 @@ labels: []
 suggested_new_path: "/orka/orka-on-aws-and-on-prem/it-administrator-onboarding-guide"
 ---
 
-This guide introduces IT administrators to managing a deployed Orka for VDI environment. Once you've completed the initial deployment following the [Orka for VDI deployment guide] this document covers ongoing operations, user management, and system maintenance.
+This guide introduces IT administrators to managing a deployed Orka for VDI environment. Once you've completed the initial deployment following the [Orka for VDI deployment guide](/remote-desktop-vdi/orka-for-vdi-deployment/deployment-guide) this document covers ongoing operations, user management, and system maintenance.
 
 **What this guide covers:**
 

--- a/orka/orka3-cli-reference/vm-deployment-and-configuration.mdx
+++ b/orka/orka3-cli-reference/vm-deployment-and-configuration.mdx
@@ -308,7 +308,7 @@ orka3 vm deploy --config small-ventura-config -c 6 --memory 16
 
 Show basic or extended information about the specified VM(s).
 
-**Note:** Stopped or suspended VMs appear as 'Running' when listed.
+<Warning>Stopped or suspended VMs appear as 'Running' when listed. Do not rely on the displayed status to confirm a VM is active before scheduling work against it.</Warning>
 
 **Syntax:**
     

--- a/orka/quick-start-guides/orka3-cli-quick-start.mdx
+++ b/orka/quick-start-guides/orka3-cli-quick-start.mdx
@@ -139,7 +139,7 @@ orka3 <parent_command> <command> --help
 
 
 ```bash
-orka3 nodes list
+orka3 node list
 ```
 This command shows basic information about the nodes in the `orka-default` namespace. Re-run this command as you deploy VM instances later on to keep track of the available resources on your nodes.
 

--- a/remote-desktop-vdi/orka-for-vdi-deployment/deployment-guide.mdx
+++ b/remote-desktop-vdi/orka-for-vdi-deployment/deployment-guide.mdx
@@ -12,7 +12,7 @@ labels: []
 suggested_new_path: "/remote-desktop-vdi/orka-for-vdi-deployment/deployment-guide"
 ---
 
-# Overview
+## Overview
 
 This guide walks through the full setup of Orka Engine Orchestration for VDI deployments. It covers network preparation, controller and host configuration, Orka Engine installation, VM deployment, and the optional Semaphore web interface.
 
@@ -25,7 +25,7 @@ There are three roles in this setup:
 
 **Note:** Total deployment time can depend on node count, but budget 30-60 minutes to set up your initial controller and host.
 
-# Prerequisites
+## Prerequisites
 
 * An Ansible controller (macOS or Linux, minimum: 2 vCPU, 4 GB RAM, 20 GB storage; recommended: 4 vCPU, 8 GB RAM, 50 GB storage)
 * One or more physical Apple Silicon based Mac hosts with macOS Sonoma, Sequoia, or Tahoe Minimum specifications per Orka host: • Apple Silicon processor (any M-series chip) • 8GB RAM • 512GB storage • 1GB Ethernet • macOS 13 (Ventura) or later
@@ -38,9 +38,9 @@ Network connectivity between the controller and all Mac hosts
 
 **Note:** Orka 3.5.0 or later is required for bridged networking support. This guide assumes that the controller is being deployed on a dedicated macOS device.
 
-# Network Configuration
+## Network Configuration
 
-## Static IP Assignment
+### Static IP Assignment
 
 Assign a static IP address to each Mac host before installing Orka Engine. Either configure the IP manually or use a DHCP reservation.
 
@@ -69,7 +69,7 @@ Document the following for each host before proceeding. This information populat
 | Network interface | en0 |
 
 
-## Firewall Requirements (Citrix DaaS)
+### Firewall Requirements (Citrix DaaS)
 
 If deploying Orka for VDI with Citrix DaaS, ensure the following traffic is permitted:
 
@@ -87,11 +87,11 @@ Inbound to VMs:
 * TCP/UDP 1494 and 2598 for HDX sessions
 
 
-# 1.  Controller Setup
+## 1.  Controller Setup
 
 Run the steps in this section on the designated Ansible controller machine.
 
-## 1.1  Set the Hostname
+### 1.1  Set the Hostname
 
 **Run on: Controller**
 Set a consistent hostname before configuring anything else. This ensures that your VDI tools are able to label the host devices accordingly. Replace example-controller with your chosen name.
@@ -103,7 +103,7 @@ sudo scutil --set HostName "example-controller"
 dscacheutil -flushcache
 ```
 
-## 1.2  Install Homebrew
+### 1.2  Install Homebrew
 
 **Run on: Controller**
 
@@ -114,7 +114,7 @@ dscacheutil -flushcache
 brew doctor
 ```
 
-## 1.3  Install Ansible
+### 1.3  Install Ansible
 
 **Run on: Controller**
 
@@ -128,11 +128,11 @@ pipx install ansible==11.4.0
 
 **Note:** Optionally install sshpass if you prefer password-based authentication instead of key exchange: brew tap esolitos/ipa && brew install esolitos/ipa/sshpass
 
-# 2.  Host Setup
+## 2.  Host Setup
 
 Run the steps in this section on each physical Mac host. Repeat for every host in your fleet.
 
-## 2.1  Set the Hostname
+### 2.1  Set the Hostname
 
 **Run on: Host(s)**
 
@@ -145,7 +145,7 @@ sudo scutil --set HostName "host0"
 dscacheutil -flushcache
 ```
 
-## 2.2  Install Homebrew
+### 2.2  Install Homebrew
 
 **Run on: Host(s)**
 
@@ -155,7 +155,7 @@ dscacheutil -flushcache
 brew doctor
 ```
 
-## 2.3  Check Python
+### 2.3  Check Python
 
 **Run on: Host(s)**
 
@@ -165,11 +165,11 @@ Python 3 is required for Ansible to manage the host. It will be installed in mac
 python3 --version
 ```
 
-# 3.  Configure SSH Access
+## 3.  Configure SSH Access
 
 Run the steps in this section on the controller. Ansible uses SSH key authentication to connect to each host.
 
-## 3.1  Generate an SSH Key
+### 3.1  Generate an SSH Key
 
 **Run on: Controller**
 
@@ -179,7 +179,7 @@ If you do not already have an SSH key, generate one. Accept the default file pat
 ssh-keygen -t ed25519
 ```
 
-## 3.2  Copy the Key to Each Host
+### 3.2  Copy the Key to Each Host
 
 **Run on: Controller**
 
@@ -195,11 +195,11 @@ Verify the connection works before moving on:
 ssh administrator@10.254.235.xx
 ```
 
-# 4.  Configure the Orchestration Library
+## 4.  Configure the Orchestration Library
 
 Run all steps in this section on the controller.
 
-## 4.1  Clone the Repository
+### 4.1  Clone the Repository
 
 **Run on: Controller**
 
@@ -212,7 +212,7 @@ git clone https://github.com/macstadium/orka-engine-orchestration.git
 cd orka-engine-orchestration
 ```
 
-## 4.2  Create the Inventory File
+### 4.2  Create the Inventory File
 
 **Run on: Controller**
 
@@ -238,7 +238,7 @@ Inventory file contents - add the IP address of each host:
 10.0.100.12
 ```
 
-## 4.3  Configure Group Variables
+### 4.3  Configure Group Variables
 
 **Run on: Controller**
 
@@ -268,7 +268,7 @@ Variable reference:
 | network_interface | (Optional) Network interface for bridged networking, e.g. en0 |
 
 
-# 5.  Install Orka Engine
+## 5.  Install Orka Engine
 
 This playbook downloads and installs the Orka Engine package on every host in your inventory. It applies the license key and starts the Orka Engine service automatically.
 
@@ -282,7 +282,7 @@ ansible-playbook install_engine.yml -i inventory -e "orka_license_key=YOUR-LICEN
 
 **Note:** Obtain your license key and installer URL from your MacStadium account representative.
 
-## 5.1  Verify the Installation
+### 5.1  Verify the Installation
 
 **Run on: Controller**
 
@@ -291,7 +291,7 @@ ansible hosts -i inventory -m shell -a "orka-engine --version"
 ansible hosts -i inventory -m shell -a "/usr/local/bin/orka-engine info"
 ```
 
-## 5.2  Force Reinstall or Upgrade
+### 5.2  Force Reinstall or Upgrade
 
 **Run on: Controller**
 
@@ -301,11 +301,11 @@ Add the install_engine_force flag to reinstall or upgrade to a newer version:
 ansible-playbook install_engine.yml -i inventory -e "orka_license_key=YOUR-LICENSE-KEY" -e "engine_url=https://distribution.macstadium.com/orka-engine/official/3.5.2/orka-engine.pkg" -e "install_engine_force=true"
 ```
 
-# 6.  Deploy and Manage VMs
+## 6.  Deploy and Manage VMs
 
 All playbook commands are run from the controller inside ~/orka-automation/orka-engine-orchestration.
 
-## 6.1  Deploy VMs
+### 6.1  Deploy VMs
 
 **Run on: Controller**
 
@@ -329,7 +329,7 @@ To preview what will be deployed without making any changes, add `--tags plan`:
 ansible-playbook deploy.yml -i inventory -e "vm_group=vdi-group" -e "desired_vms=4" --tags plan
 ```
 
-## 6.2  List VMs
+### 6.2  List VMs
 
 **Run on: Controller**
 
@@ -337,7 +337,7 @@ ansible-playbook deploy.yml -i inventory -e "vm_group=vdi-group" -e "desired_vms
 ansible-playbook list.yml -i inventory -e "vm_group=vdi-group"
 ```
 
-## 6.3  Manage Individual VMs
+### 6.3  Manage Individual VMs
 
 **Run on: Controller**
 
@@ -347,7 +347,7 @@ Start, stop, or delete a specific VM by name. Valid values for desired_state are
 ansible-playbook vm.yml -i inventory -e "vm_name=my-vm-name" -e "desired_state=running"
 ```
 
-## 6.4  Delete VMs
+### 6.4  Delete VMs
 
 **Run on: Controller**
 
@@ -357,7 +357,7 @@ Delete a specific number of VMs from a group. Add --tags plan to preview before 
 ansible-playbook delete.yml -i inventory -e "vm_group=vdi-group" -e "delete_count=2"
 ```
 
-## 6.5  Pull Images
+### 6.5  Pull Images
 
 **Run on: Controller**
 
@@ -367,11 +367,11 @@ Pre-pull an image to all hosts so it is ready for fast deployment:
 ansible-playbook pull_image.yml -i inventory -e "remote_image_name=ghcr.io/macstadium/orka-images/sequoia:latest"
 ```
 
-# 7.  Semaphore Web UI (Optional)
+## 7.  Semaphore Web UI (Optional)
 
 Semaphore provides a browser-based interface for running orchestration playbooks without CLI access. All task templates, inventory, and repository configuration are set up automatically on first launch.
 
-## 7.1  Install Docker
+### 7.1  Install Docker
 
 **Run on: Controller**
 
@@ -383,7 +383,7 @@ brew install docker docker-compose
 
 **Note:** Docker Desktop is an alternative if you prefer a GUI installer. Either option works.
 
-## 7.2  Configure the Environment
+### 7.2  Configure the Environment
 
 **Run on: Controller**
 
@@ -415,7 +415,7 @@ SEMAPHORE_ACCESS_KEY_ENCRYPTION=your-generated-key-here
 
 Also set your admin username and password in the same file before starting Semaphore.
 
-## 7.3  Start Semaphore
+### 7.3  Start Semaphore
 
 **Run on: Controller**
 
@@ -426,11 +426,11 @@ docker compose up -d
 
 Semaphore is available at `http://localhost:3000`. Log in with the admin credentials you set in the `.env` file.
 
-## 7.4  Configure SSH Credentials
+### 7.4  Configure SSH Credentials
 
 After logging in, navigate to Key Store and edit the Mac Hosts SSH key. Replace the placeholder credentials with the actual SSH username and private key (or password) for your Mac hosts.
 
-## 7.5  Available Task Templates
+### 7.5  Available Task Templates
 
 The following templates are pre-configured and ready to use in the Orka Engine Orchestration project. Each template prompts for required inputs when you click Run.
 
@@ -445,7 +445,7 @@ The following templates are pre-configured and ready to use in the Orka Engine O
 | Create Image | create_image.yml | remote_image_name, vm_image |
 
 
-## 7.6  Stop Semaphore
+### 7.6  Stop Semaphore
 
 Stop containers but keep data
 
@@ -459,15 +459,15 @@ Stop and remove all data (database, task history)
 docker compose down -v
 ```
 
-# 8.  Image Management
+## 8.  Image Management
 
-## 8.1  Using MacStadium Public Images
+### 8.1  Using MacStadium Public Images
 
 MacStadium maintains public base images through GitHub Container Registry. No authentication is required. Reference them by OCI path: `ghcr.io/macstadium/orka-images/[os-version]:latest`
 
 Available images include Tahoe, Sequoia, Ventura, and Sonoma. Use the image name matching your target macOS version.
 
-## 8.2  Building a Custom Golden Image
+### 8.2  Building a Custom Golden Image
 
 For VDI deployments, build a golden image with Citrix VDA and your organization's software pre-installed. The `create_image.yml` playbook deploys a temporary VM from a base image, runs your customization scripts, pushes the resulting image to your registry, then cleans up the VM.
 
@@ -479,7 +479,7 @@ Add your customization scripts to the /scripts folder in the repository, then ru
 ansible-playbook create_image.yml -i inventory -e "vm_image=ghcr.io/macstadium/orka-images/sequoia:latest" -e "remote_image_name=registry.example.com/citrix-vda/sequoia-golden:v1.0"
 ```
 
-## 8.3  Distributing Images to Hosts
+### 8.3  Distributing Images to Hosts
 
 Pre-pull images to all hosts before deploying VMs to avoid pull delays at deployment time:
 
@@ -489,7 +489,7 @@ Pre-pull images to all hosts before deploying VMs to avoid pull delays at deploy
 ansible-playbook pull_image.yml -i inventory -e "remote_image_name=registry.example.com/citrix-vda/sequoia-golden:v1.0"
 ```
 
-## 8.4  Private Registry Naming
+### 8.4  Private Registry Naming
 
 If using a self-hosted registry (Harbor, Docker Registry, JFrog Artifactory), use a consistent naming convention:
 
@@ -499,7 +499,7 @@ If using a self-hosted registry (Harbor, Docker Registry, JFrog Artifactory), us
 
 **Note:** Store registry credentials in Ansible Vault, never in plain text. Exclude vault files from Git using .gitignore.
 
-# 9.  Repository and Version Control
+## 9.  Repository and Version Control
 
 Fork the `orka-engine-orchestration` repository on GitHub so you can customize it and track changes over time.
 •    Add a `.gitignore` to exclude SSH keys, vault files, and other secrets.
@@ -508,7 +508,7 @@ Fork the `orka-engine-orchestration` repository on GitHub so you can customize i
 •    Use separate branches for staging and production changes.
 •    Document your inventory structure and playbook customizations in the repository `README`.
 
-# Support Resources
+## Support Resources
 
 **Note:** The following remote host CLI commands are for advanced troubleshooting and diagnostics. It is recommended to use the Ansible playbooks or Semaphore UI when available.
 


### PR DESCRIPTION
## Summary

Second fix batch from multi-persona QA audit — 6 files, all confirmed bugs.

- **Command typo**: `orka3 nodes list` → `orka3 node list` in CLI quick-start
- **Frontmatter bug**: `drone.mdx` had an absolute `https://support.macstadium.com/...` URL as `zendesk_url` — the only file with an absolute URL; fixed to relative path
- **Broken link**: `[Orka for VDI deployment guide]` in IT admin onboarding guide had no URL — added correct path
- **AWS VPN doc fixes** (5 issues in one file):
  - Removed duplicate step 6 ("Log in to WS Management Console") which was a repeat of step 1 with a typo
  - Fixed "IP IP Plan ( )" → "IP Plan" (duplicate word + empty parens placeholder)
  - Fixed Appendix B → Appendix A for Private-1 network in Note block
  - Rewrote malformed `<.code>` tag in uncomment instruction as clean markdown
- **Warning promotion**: Stopped/suspended VM status gotcha in vm-deployment-and-configuration promoted from `**Note:**` to `<Warning>` — easy to miss, causes scheduling issues
- **Heading hierarchy**: `deployment-guide.mdx` used H1 for all section headers, breaking Mintlify's TOC. Cascaded H1→H2 and H2→H3 throughout the file.

## Test plan

- [ ] Verify Mintlify preview builds without errors on all 6 files
- [ ] Confirm `orka3 node list` (no 's') renders correctly in CLI quick-start
- [ ] Confirm drone.mdx frontmatter has a relative zendesk_url
- [ ] Confirm deployment-guide.mdx TOC shows correct nested hierarchy in Mintlify preview
- [ ] Spot-check AWS VPN doc: step list ends at step 5, uncomment instruction is readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)