### PR TITLE
Fix frontmatter and em dash in claude-code.mdx

### DIFF
--- a/orka/orka-devops-integrations/claude-code.mdx
+++ b/orka/orka-devops-integrations/claude-code.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Claude Code"
-description: "Use Claude Code with the Orka3 CLI skill to get contextual AI assistance for managing your Orka cluster — deploy VMs, troubleshoot issues, and build CI/CD workflows without leaving your terminal."---
+description: "Use Claude Code with the Orka3 CLI skill to get contextual AI assistance for managing your Orka cluster — deploy VMs, troubleshoot issues, and build CI/CD workflows without leaving your terminal."
+---
 
 The Orka3 CLI skill gives [Claude Code](https://claude.ai/code) deep knowledge of the Orka CLI and, when you're authenticated and connected to the VPN, the ability to run commands directly against your cluster. You can ask questions in plain English, have Claude generate and execute `orka3` commands on your behalf, or use it to build and test automation workflows — all from your terminal.
 
@@ -49,6 +50,6 @@ You'll need Claude Code installed and a valid Anthropic API key. The skill insta
 ## Tips for getting the most out of it
 
 - **Give Claude context about your environment.** Mention whether you're on Intel or Apple Silicon nodes, and which Orka version you're running. Claude will tailor commands accordingly.
-- **For CI/CD questions, describe your pipeline.** Tell Claude which CI platform you're using and whether you're running inside a container — the auth approach is different.
+- **For CI/CD questions, describe your pipeline.** Tell Claude which CI platform you're using and whether you're running inside a container. The auth approach is different.
 - **Ask follow-up questions.** If a suggested command doesn't match your setup, explain why and Claude will adjust.
 - **For long-running operations, ask how to check status.** Image saves, commits, and pushes are async. Claude knows the right status-check commands.


### PR DESCRIPTION
## Summary

Two small fixes missed from PR #80:

- Missing newline before closing `---` caused the entire frontmatter block to render as visible body text on the page
- Removed em dash in the CI/CD tips bullet

## Test plan

- [x] `https://docs.macstadium.com/orka/orka-devops-integrations/claude-code` no longer shows raw frontmatter at the top of the page
- [x] Tips section renders as clean bullet points

🤖 Generated with [Claude Code](https://claude.com/claude-code)