### PR TITLE
Formatting batch 2: fix misused code blocks in VDI docs

### DIFF
--- a/iaas/bare-metal-macs/vnc-clients.mdx
+++ b/iaas/bare-metal-macs/vnc-clients.mdx
@@ -16,11 +16,13 @@ macOS X comes equipped with Virtual Network Computing (VNC) capabilities. Althou
 
 A **VNC client** running on a Mac or PC can easily connect to a **VNC server** running on your remote Mac mini.
 
-> ##  🚧VNC Compatibility
-> 
-> Mac-to-Mac sessions are inherently reliable, because they're using the same version of VNC code on both sides of the connection.
-> 
-> PC or Linux to Mac connections have been known to occasionally exhibit buggy behavior, but in most cases you will have no trouble if your software is up to date.
+<Note>
+  **VNC Compatibility**
+
+  Mac-to-Mac sessions are inherently reliable, because they're using the same version of VNC code on both sides of the connection.
+
+  PC or Linux to Mac connections have been known to occasionally exhibit buggy behavior, but in most cases you will have no trouble if your software is up to date.
+</Note>
 
 VNC is based on open source software, which is why there are several versions that have been developed independently from the same starting point (i.e. the open source version). This means that each of the following VNC clients (which will allow your local computer to talk to your remote Mac mini) share similar capabilities, although there are some differences as well. Moreover, each offers a free and a paid service tier -- with certain features only offered via the paid tier.
 
@@ -34,9 +36,9 @@ VNC is based on open source software, which is why there are several versions th
 
 UltraVNC is a newer fork of the original VNC codebase that adds video compression to improve performance, a nifty graphical toolbar and an optional encryption module. It also seems to be a bit more stable than RealVNC. If you don’t already have the RealVNC client installed, this version is preferable to RealVNC just for these few additional features.
 
-> ##  🚧Note:
-> 
-> The encryption module will not work with the pre-installed OS X server though – you would need to install a different VNC server (such as Vine) on the Mac mini in order to take advantage of that feature.
+<Note>
+  The encryption module will not work with the pre-installed OS X server though – you would need to install a different VNC server (such as Vine) on the Mac mini in order to take advantage of that feature.
+</Note>
 
 ## TeamViewer
 

--- a/iaas/cisco-firewalls/allowing-specific-ips-to-access-macstadium-via-internet.mdx
+++ b/iaas/cisco-firewalls/allowing-specific-ips-to-access-macstadium-via-internet.mdx
@@ -24,7 +24,9 @@ In this document, the source IP address is the public IP that needs to be whitel
 
 This document demonstrates how to allow TCP port 443 (HTTPS) in the Cisco Adaptive Security Appliance (ASA) firewall from an external IP address to the subnet 10.221.188.0/23 configured in the Private-1 interface as an example.
 
-**NOTE** : The example source IP address **76.76.21.241** is used in this document.
+<Note>
+  The example source IP address **76.76.21.241** is used in this document.
+</Note>
 
 ## Install Options
 
@@ -53,11 +55,18 @@ ciscoasa#``
      * The privileged mode appears, as indicated by the # prompt.
   4. Enter the configuration mode and create an object and static NAT rule for that host:
 
+```
+ciscoasa#configure terminal
+ciscoasa(config)#object network Example-Host-31
+ciscoasa(config-network-object)#host 10.221.188.31
+ciscoasa(config-network-object)#nat (Private-1,Outside) static 207.254.16.239
+ciscoasa(config-network-object)#end
+ciscoasa#write memory
+```
 
-
-` ciscoasa#configure terminal ciscoasa(config)#object network Example-Host-31 ciscoasa(config-network-object)#host 10.221.188.31 ciscoasa(config-network-object)#nat (Private-1,Outside) static 207.254.16.239 ciscoasa(config-network-object)#end ciscoasa#write memory `
-
-**NOTE:** Replace the example MacStadium NAT IP address (207.254.16.239) by an available Public IP listed in the MacStadium IP Plan.
+<Note>
+  Replace the example MacStadium NAT IP address (207.254.16.239) with an available Public IP listed in the MacStadium IP Plan.
+</Note>
 
 ## NAT via Cisco Adaptive Security Device Manager (ASDM)
 
@@ -82,30 +91,66 @@ ciscoasa#``
 
 ### ACL via Command Line Interface (CLI)
 
-**NOTE** : For external access to MacStadium hosts, a static NAT must be previously configured.1.
+<Note>
+  For external access to MacStadium hosts, a static NAT must be previously configured.
+</Note>
 
-**NOTE** : This guide assumes that the `Private-1-IPs` object has been configured in the firewall.
+<Note>
+  This guide assumes that the `Private-1-IPs` object has been configured in the firewall.
+</Note>
 
   1. Confirm that `Private-1-IPs` was configured by running the following CLI command:  
 `ciscoasa#show running-config object id Private-1-IPs`
-  2. If `Private-1-IPs` has not been configured, then use the following commands to create it:  
-` ciscoasa#configure terminal ciscoasa(config)#object network Private-1-IPs ciscoasa(config-network-object)#subnet 10.221.188.0 255.255.254.0`
+  2. If `Private-1-IPs` has not been configured, then use the following commands to create it:
+
+```
+ciscoasa#configure terminal
+ciscoasa(config)#object network Private-1-IPs
+ciscoasa(config-network-object)#subnet 10.221.188.0 255.255.254.0
+```
   3. Connect to the firewall via SSH and from the command line enter the MacStadium credentials that are available in your [IP Plan](/macstadium/macstadium-overview/ip-plan)
   4. Confirm the privileged mode is enabled (indicated by the # prompt).
   5. Enter the configuration mode and create an Object representing the source IP address.
-  6. Replace EXAMPLE with a name to use to identify the object and the source Public IP address (**76.76.21.241**) with the source IP address to whitelist on the firewall.  
-`ciscoasa#configure terminal ciscoasa(config)#object network EXAMPLE ciscoasa(config-network-object)#host 76.76.21.241`
-  7. Create an Access Control List to allow traffic through the Cisco ASA firewall. From the configuration mode enter the following access-list command:  
-`ciscoasa(config)#access-list Outside_access_in line 1 extended permit tcp object EXAMPLE object Private-1-IPs eq https`
-     * **NOTE** : To allow access to a single internal host instead of the entire Private-1 network, reference the object you created for that specific host. Example: `ciscoasa(config)#access-list Outside_access_in line 1 extended permit tcp object EXAMPLE object Example-Host-31 eq https`
-  8. Apply the new access-list to the Outside interface: `ciscoasa(config)#access-group Outside_access_in in interface Outside`
-     * **NOTE** : The command above only needs to be entered the first time the ACL is configured.
-  9. Exit and save the configuration:  
-`ciscoasa(config)#end ciscoasa(config)#write memory`
+  6. Replace EXAMPLE with a name to use to identify the object and the source Public IP address (**76.76.21.241**) with the source IP address to whitelist on the firewall.
+
+```
+ciscoasa#configure terminal
+ciscoasa(config)#object network EXAMPLE
+ciscoasa(config-network-object)#host 76.76.21.241
+```
+
+  7. Create an Access Control List to allow traffic through the Cisco ASA firewall. From the configuration mode enter the following access-list command:
+
+```
+ciscoasa(config)#access-list Outside_access_in line 1 extended permit tcp object EXAMPLE object Private-1-IPs eq https
+```
+
+<Note>
+  To allow access to a single internal host instead of the entire Private-1 network, reference the object you created for that specific host. Example: `ciscoasa(config)#access-list Outside_access_in line 1 extended permit tcp object EXAMPLE object Example-Host-31 eq https`
+</Note>
+
+  8. Apply the new access-list to the Outside interface:
+
+```
+ciscoasa(config)#access-group Outside_access_in in interface Outside
+```
+
+<Note>
+  The command above only needs to be entered the first time the ACL is configured.
+</Note>
+
+  9. Exit and save the configuration:
+
+```
+ciscoasa(config)#end
+ciscoasa(config)#write memory
+```
 
 
 
-**NOTE** : Instead of creating an object representing a single source IP Address, create a Network Object Group and then add a Network Object to that group. This is handy if there are liable to be more IP addresses to allow access in the future. For more information, see:
+<Note>
+  Instead of creating an object representing a single source IP address, you can create a Network Object Group and add Network Objects to it. This is useful if you expect to allow more IP addresses in the future. For more information, see:
+</Note>
 
 [Cisco ASA 9.6 Access Objects Guide](https://www.cisco.com/c/en/us/td/docs/security/asa/asa96/configuration/firewall/asa-96-firewall-config/access-objects.html)
 
@@ -131,14 +176,11 @@ For external access to your MacStadium hosts, a static NAT must be previously co
   14. Click OK.  
 ![4ab3a50-image.png](/images/attachments/28269995156635.png)  
 
-```
- * **NOTE** : To allow access to a single internal host instead of the entire Private-1 network, reference the object created for that specific host in the Destination field.14
-```
-  15. Make sure the new rule is at the TOP.  
+<Note>
+  To allow access to a single internal host instead of the entire Private-1 network, reference the object created for that specific host in the Destination field.
+</Note>
 
-```
- * To move the new rule to the top, select the new rule and click the upper arrow highlighted.  
-```
+  15. Make sure the new rule is at the TOP. To move the new rule to the top, select the new rule and click the upper arrow highlighted.
 ![2f3cf6b-image.png](/images/attachments/28269981359131.png)
 
   16. Click Apply

--- a/iaas/cisco-firewalls/backup-and-restore-firewall-config-using-asdm.mdx
+++ b/iaas/cisco-firewalls/backup-and-restore-firewall-config-using-asdm.mdx
@@ -10,7 +10,9 @@ This process outlines how to backup and restore a configuration by executing lin
 
 The backup files are stored on a local system as a ZIP file.
 
-**NOTE** : It is important to store this ZIP file in an easily accessible place in case of an emergency. Plan a backup to be taken anytime changes are made to the firewall configuration.
+<Note>
+  It is important to store this ZIP file in an easily accessible place in case of an emergency. Plan a backup to be taken anytime changes are made to the firewall configuration.
+</Note>
 
 If the firewall configuration is in a high-availability (HA) Pair, then ensure that the backup and restore to the Active firewall is enabled. This can be verified on the Cisco Adaptive Security Device Manager (ASDM) Dashboard, under the **Failover Status** field. Look for **Primary (Active)**. If this is not enabled, then login to the other firewall to perform these steps.
 
@@ -22,7 +24,9 @@ If the firewall configuration is in a high-availability (HA) Pair, then ensure t
 
 
 
-**NOTE** : If a passphrase was set on the backup, then it needs to be available during the restore process.
+<Note>
+  If a passphrase was set on the backup, then it needs to be available during the restore process.
+</Note>
 
 ## Backup Process
 
@@ -40,16 +44,17 @@ If the firewall configuration is in a high-availability (HA) Pair, then ensure t
   9. Click Backup.  
 ![761fe82-image \(1\).png](/images/attachments/28277009636251.png)  
 
-```
- * **OPTIONAL** : If the firewall is configured with identity certificates, then select a passphrase to encrypt identity certificates. Document the passphrase that is used as it is needed for future restores.  
-```
+<Note>
+  **Optional:** If the firewall is configured with identity certificates, then select a passphrase to encrypt identity certificates. Document the passphrase that is used as it is needed for future restores.
+</Note>
 ![045969f-image.png](/images/attachments/28277009642139.png)
 
   10. Click OK  
 
-```
- * **NOTE** : The Progress Message can be copied to a text editor for review and validation.
-```
+<Note>
+  The Progress Message can be copied to a text editor for review and validation.
+</Note>
+
   11. Click Close after backup is completed. A Backup Statistics window opens and displays additional information about the Backup process.  
 ![092cb90-image.png](/images/attachments/28277009648155.png)
   12. Click OK  
@@ -70,50 +75,49 @@ If the firewall configuration is in a high-availability (HA) Pair, then ensure t
 ![576de37-image.png](/images/attachments/28277042174747.png)
   7. From the Restore Configurations pop-up page, select the options to restore.  
 
-```
- * **RECOMMENDED SETTINGS:**
+<Note>
+  **Recommended settings:**
 
-   * Running configuration
-
-   * Start-up configuration
-
-   * All Security Images
-
-   * Identity Certificates
-
-   * Leave the remaining default options untouched  
-```
+  - Running configuration
+  - Start-up configuration
+  - All Security Images
+  - Identity Certificates
+  - Leave the remaining default options untouched
+</Note>
 ![0daf363-image.png](/images/attachments/28277042179227.png)
 
   8. Click Restore.
   9. You should now see the below message. Click Yes.  
 ![dc7fa4e-image.png](/images/attachments/28277009661339.png)  
 
-```
- * **NOTE** : If applicable, enter the Certificate Passphrase used to backup the identity Certificate, then click the OK.  
-```
+<Note>
+  If applicable, enter the Certificate Passphrase used to backup the identity Certificate, then click OK.
+</Note>
 ![bb30c48-image.png](/images/attachments/28277042184091.png)
 
-```
- * **NOTE** : The following message may appear during the Restore Progress. Select Refresh Now or Cancel button. Choosing Cancel will not halt the Restore process.  
-```
+<Note>
+  The following message may appear during the Restore Progress. Select Refresh Now or Cancel button. Choosing Cancel will not halt the Restore process.
+</Note>
 ![1d021b9-image.png](/images/attachments/28277042189339.png)
-  10. Once the Restore process is complete, click Close. 
-     * **NOTE** :The Progress Message can be copied to a text editor for review and validation.
+  10. Once the Restore process is complete, click Close.
+
+<Note>
+  The Progress Message can be copied to a text editor for review and validation.
+</Note>
 
 ![4431f75-image.png](/images/attachments/28277009667995.png)
   11. To verify the restore process, close the ASDM application and then relaunch it.
   12. Review the configuration that is loaded with the device manager.
-  13. Close the application. 
-     * **NOTE** : The following Unapplied Changes message box may appear:
+  13. Close the application.
+
+<Note>
+  The following Unapplied Changes message box may appear:
+</Note>
 
 ![c58aece-image.png](/images/attachments/28277042199707.png)
 
-```
-   * If the Unapplied Changes message box appears, then click Apply Changes.
-
-   * If the Unapplied Changes message box does not appear, then click Save in the ASDM application.
-```
+- If the Unapplied Changes message box appears, then click Apply Changes.
+- If the Unapplied Changes message box does not appear, then click Save in the ASDM application.
 ## Additional Notes:
 
   * If firewall access enables the backup process but does not enable the restore process, then open a MacStadium Support ticket.

--- a/iaas/cisco-firewalls/creating-local-user-accounts-on-a-cisco-asa.mdx
+++ b/iaas/cisco-firewalls/creating-local-user-accounts-on-a-cisco-asa.mdx
@@ -14,9 +14,13 @@ This document describes how to create local user accounts on the Cisco ASA, usin
 
 The details in this document are based on a Cisco ASA virtual firewall that runs ASA code version 9.14(3)18 and ASDM version 7.18.(1)152, and was created from these devices in a specific lab environment.
 
-**NOTE** : The device used in this document started with a cleared (default) configuration.
+<Note>
+  The device used in this document started with a cleared (default) configuration.
+</Note>
 
-**WARNING** : For a live network, consider the potential impact before executing any commands.
+<Warning>
+  For a live network, consider the potential impact before executing any commands.
+</Warning>
 
 MacStadium configured a shared user account for customers to use for accessing the firewall. It was also used for authentication for the environment behind the firewall, and used a Remote Access VPN (RAVPN) client. This user account was configured with the highest access level.
 
@@ -47,14 +51,14 @@ Using an ASDM allows you to make line-by-line changes, while using a graphical u
   5. Create the new user account by typing the command in the following format: `username username password password privilege priv_level`
      * **NOTES:**
 
-```
-   * The username username keyword is a string from 3 to 64 characters long. The space and question mark characters cannot be used for usernames.
-   * The password password keyword is a string from 3 to 127 characters long. The space and question mark characters cannot be used within the passwords.
-   * The privilege priv_level keyword sets the privilege level for the created user account. The priv_level is a numeric value ranging from 0 to 15.
-   * By default, a user account has a privilege level of 2.
-   * A level of 15 grants the user account the highest level of access.
-   * An example of the CLI command is `ciscoasa(config)# username exampleuser1 password examplepassword privilege 1`
-```
+<Note>
+  - The `username` keyword is a string from 3 to 64 characters long. The space and question mark characters cannot be used for usernames.
+  - The `password` keyword is a string from 3 to 127 characters long. The space and question mark characters cannot be used within the passwords.
+  - The `privilege priv_level` keyword sets the privilege level for the created user account. The `priv_level` is a numeric value ranging from 0 to 15.
+  - By default, a user account has a privilege level of 2.
+  - A level of 15 grants the user account the highest level of access.
+  - Example: `ciscoasa(config)# username exampleuser1 password examplepassword privilege 1`
+</Note>
   6. Save the configuration with the command `write memory`
   7. Type the exit or end command to return to privileged mode of the ASA.
 
@@ -143,37 +147,49 @@ To remove a user account, use `no version` with the username that is being remov
 
 ## Connect to the Cisco ASA using SSH
 
-  1. Configure aaa to use local database for ssh and console  
+  1. Configure aaa to use local database for ssh and console:
 
 ```
- * `ciscoasa# aaa authentication ssh console LOCAL`
- * **NOTE** : aaa = authentication (permitting access), authorization (specify commands when granted access), accounting (keeps track of utilization reports of users after logged in and generate accounting reports for billing)  
+ciscoasa# aaa authentication ssh console LOCAL
 ```
-LOCAL = local database
-  2. Create admin username with privilege 15 (username, P@ssw0rd)  
+
+<Note>
+  `aaa` = authentication (permitting access), authorization (specify commands when granted access), accounting (keeps track of utilization reports of users after logged in and generates accounting reports for billing). `LOCAL` = local database.
+</Note>
+
+  2. Create admin username with privilege 15:
 
 ```
- * `ciscoasa# username username password P@ssw0rd priv 15`
- * **NOTE** : priv 15 = top privilege level (full superuser, can give different command access to different privilege levels)
+ciscoasa# username username password P@ssw0rd priv 15
 ```
-  3. Turn on password for enable.  
+
+<Note>
+  `priv 15` = top privilege level (full superuser, can give different command access to different privilege levels).
+</Note>
+
+  3. Turn on password for enable:
 
 ```
- * `ciscoasa# aaa authentication enable console LOCAL`
- * This forces a password for the enable prompt.
+ciscoasa# aaa authentication enable console LOCAL
 ```
-  4. Turn on serial console authentication.  
+
+This forces a password for the enable prompt.
+
+  4. Turn on serial console authentication:
 
 ```
- * `ciscoasa# aaa authentication serial console LOCAL`
- * This turns on user/pass for serial access.
+ciscoasa# aaa authentication serial console LOCAL
 ```
-  5. Save changes  
+
+This turns on user/pass for serial access.
+
+  5. Save changes:
 
 ```
- * `ciscoasa# write mem`
+ciscoasa# write mem
 ```
-  6. Log out console and verify access.  
+
+  6. Log out console and verify access.
 
 
 `ciscoasa(config)# end`
@@ -186,37 +202,34 @@ LOCAL = local database
 
 `Password: ********`
 
-  7. Generate ssh key pair.  
+  7. Generate ssh key pair:
 
 ```
- * `ciscoasa# crypto key generate rsa modulus 4096`
-
- * The name for the keys will be:
-
-   * Keypair generation process begin. Please wait…
-
-   * ciscoasa(config)#
-
- * SSH is an encrypted protocol, uses RSA to generate public and private key
-
- * 4096 = block size
-
- * rsa = encryption algorithm
+ciscoasa# crypto key generate rsa modulus 4096
 ```
-  8. Allow access to the inside interface.  
+
+<Note>
+  SSH is an encrypted protocol that uses RSA to generate public and private keys. `4096` = block size, `rsa` = encryption algorithm. The prompt will show `Keypair generation process begin. Please wait…` followed by `ciscoasa(config)#`.
+</Note>
+
+  8. Allow access to the inside interface:
 
 ```
- * `ciscoasa# ssh 0.0.0.0 0.0.0.0 inside`
- * This enables ssh access to the inside interface from any IPv4
+ciscoasa# ssh 0.0.0.0 0.0.0.0 inside
 ```
-  9. Force ssh version 2.  
+
+This enables SSH access to the inside interface from any IPv4 address.
+
+  9. Force ssh version 2:
 
 ```
- * `ciscoasa# ssh version 2`
+ciscoasa# ssh version 2
 ```
-  10. Add timeout of 15 min to ssh.  
+
+  10. Add a 15-minute timeout to ssh:
 
 ```
- * `ciscoasa# ssh timeout 15`
+ciscoasa# ssh timeout 15
 ```
+
   11. Verify login with ssh through 192.168.1.1 in putty.

--- a/iaas/cisco-firewalls/network-firewalls-cloud-connect-vpn.mdx
+++ b/iaas/cisco-firewalls/network-firewalls-cloud-connect-vpn.mdx
@@ -4,11 +4,12 @@ description: "Connect to your MacStadium Orka cluster via Cisco ASAv VPN with Op
 zendesk_id: 28244765690395
 ---
 
-> **📘 Requirements:**
-> 
->   * The server address from **Step 1: VPN** in the [IP Plan](https://docs.macstadium.com/docs/ip-plan).
->   * The username and password from **Step 1: VPN** in the [IP Plan](https://docs.macstadium.com/docs/ip-plan).
-> 
+<Tip>
+  **Requirements:**
+
+  - The server address from **Step 1: VPN** in the [IP Plan](https://docs.macstadium.com/docs/ip-plan).
+  - The username and password from **Step 1: VPN** in the [IP Plan](https://docs.macstadium.com/docs/ip-plan).
+</Tip>
 
 
 ## About
@@ -22,7 +23,9 @@ The Orka cluster sits behind its dedicated Cisco ASAv firewall, which must be co
 
 
 
-📘 MacStadium has pre-configured the firewall and has enabled VPN access. Simply run a VPN client and provide the server address and credentials for the connection.
+<Tip>
+  MacStadium has pre-configured the firewall and has enabled VPN access. Simply run a VPN client and provide the server address and credentials for the connection.
+</Tip>
 
 ****
 
@@ -62,11 +65,12 @@ The DNS server address is the `.251` address for the `Private-1` network from th
 **Linux**
 
   1. Use a text editor to open `/etc/resolv.conf`.
-  2. Locate the nameserver section and add the Orka DNS address: 
-         
-```
+  2. Locate the nameserver section and add the Orka DNS address:
+
+     ```
      nameserver <ORKA-DNS-ADDRESS>
-```
+     ```
+
   3. Make sure that this is the first nameserver entry in the list.
 
 
@@ -88,13 +92,13 @@ The DNS server address is the `.251` address for the `Private-1` network from th
 
 ### Use OpenConnect
 
-  1. From the command line, run the following command. Replace \<SERVER ADDRESS> with the server address from Step 1: VPN in the IP Plan. 
-         
-```
-     sudo openconnect <SERVER ADDRESS> --protocol=anyconnect  
-     // OR if running on Windows  
+  1. From the command line, run the following command. Replace \<SERVER ADDRESS> with the server address from Step 1: VPN in the IP Plan.
+
+     ```
+     sudo openconnect <SERVER ADDRESS> --protocol=anyconnect
+     // OR if running on Windows
      openconnect <SERVER ADDRESS> --protocol=anyconnect
-```
+     ```
   2. Follow the prompts. 
      * On the immediate Password prompt, provide the sudo password (the password for the current computer user) and press Enter.
      * On the Enter 'yes' to accept, 'no' to abort; anything else to view: prompt, type yes and press Enter.
@@ -107,9 +111,11 @@ When the connection is established, a similar output (show below) appears:
 
 ![openconnect-1.png](/images/attachments/openconnect-1.png)
 
-> 👍 **Want to terminate the VPN connection?**
-> 
-> At any time press `Ctrl+C` on the command line.
+<Tip>
+  **Want to terminate the VPN connection?**
+
+  At any time press `Ctrl+C` on the command line.
+</Tip>
 
 ## Cisco AnyConnect Secure Mobility Client
 
@@ -159,13 +165,11 @@ With Cisco AnyConnect already connected to your cluster:
 ![ciscologin.png](/images/attachments/ciscologin.png)  
   
 
-  3. If prompted that an untrusted server was blocked, perform the following steps:  
+  3. If prompted that an untrusted server was blocked, perform the following steps:
 
-```
- * Click Change Setting... and deselect Block connections to untrusted servers.
- * Close the Preferences - VPN window.
- * Click Connect again.  
-```
+     - Click Change Setting... and deselect Block connections to untrusted servers.
+     - Close the Preferences - VPN window.
+     - Click Connect again.
 ![blockconnections.png](/images/attachments/blockconnections.png)  
   
 

--- a/iaas/iaas-faqs/macstadium-api.mdx
+++ b/iaas/iaas-faqs/macstadium-api.mdx
@@ -31,8 +31,8 @@ curl -H "Accept: application/json" -H "Content-Type: application/json" -H 'Autho
 ```
 ### Server Status by ID/IP
 
-URI: https://api.macstadium.com/core/api/servers/\{id or ip_address}  
-Request: GET  
+URI: https://api.macstadium.com/core/api/servers/{id or ip_address}
+Request: GET
 Return: JSON array\{id,name,power, type, location, status, creation date, cancel date} or error string. Power can be ‘On’, ‘Off’, ‘Rebooting’, or ‘Error’.  
 **Example 1:**
     
@@ -48,7 +48,7 @@ curl -H "Accept: application/json" -H "Content-Type: application/json" -X GET -H
 ```
 ### Server Action (Power) by ID/IP
 
-URI: https://api.macstadium.com/core/api/servers/\{id or ip_address}/\{action}  
+URI: https://api.macstadium.com/core/api/servers/{id or ip_address}/{action}  
 Request: GET  
 Params: Action can be ‘On’,’Off’, or ‘Reboot’ (case insensitive).  
 Return: String. ‘True’ on success or an error message.  

--- a/orka/kubernetes-native/k8s-native-persistent-volumes.mdx
+++ b/orka/kubernetes-native/k8s-native-persistent-volumes.mdx
@@ -67,18 +67,18 @@ A persistent volume claim (PVC) lets you tap into your persistent volume and con
   1. Create the PVC manifest. For more information, see [Kubernetes Documentation: PersistentVolumeClaims](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims). For example:  
 **pvc.yml**
          
-```
-     # pvc.yaml  
-     kind: PersistentVolumeClaim  
-     apiVersion: v1  
-     metadata:  
-     name: mypvc  
-     spec:  
-     accessModes:  
-     - ReadWriteOnce  
-     resources:  
-     requests:  
-     storage: 20Gi
+```yaml
+# pvc.yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: mypvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
 ```
 The values for metadata:name and metadata:namespace must match the values for claimRef:name and claimRef:namespace declared in the manifest of the persistent volume. Double-check with the MacStadium team for these values.
 
@@ -109,27 +109,27 @@ Now that you have created a PVC and bound it to the PV, you can deploy a pod tha
   1. Create the pod manifest. The pod needs to reference both the PV and the PVC. For example:  
 mypod.yaml 
          
-```
-     apiVersion: v1  
-     kind: Pod  
-     metadata:  
-     name: mypod  
-     spec:  
-     volumes:  
-     - name: my-pv  
-     persistentVolumeClaim:  
-     claimName: mypvc  
-     containers:  
-     - name: mypod  
-     image: ubuntu  
-     command: ["/bin/bash", "-ec", "while :; do echo '.'; sleep 5 ; done"]  
-     volumeMounts:  
-     - mountPath: "/usr/share/mypod"  
-     name: my-pv  
-     restartPolicy: Never  
-     tolerations:  
-     - key: orka.macstadium.com/namespace-reserved  
-     value: <NAMESPACE>
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mypod
+spec:
+  volumes:
+    - name: my-pv
+      persistentVolumeClaim:
+        claimName: mypvc
+  containers:
+    - name: mypod
+      image: ubuntu
+      command: ["/bin/bash", "-ec", "while :; do echo '.'; sleep 5 ; done"]
+      volumeMounts:
+        - mountPath: "/usr/share/mypod"
+          name: my-pv
+  restartPolicy: Never
+  tolerations:
+    - key: orka.macstadium.com/namespace-reserved
+      value: <NAMESPACE>
 ```
 This example deploys a Linux VM. Pay attention to the command line and the tolerations section. Without the command line, the state of your Linux VM will become Stopped. Without the tolerations section, you won't be able to create the pod.
 

--- a/orka/orka-desktop/welcome-to-orka-desktop-30.mdx
+++ b/orka/orka-desktop/welcome-to-orka-desktop-30.mdx
@@ -10,9 +10,9 @@ zendesk_id: 28396626048667
 
 **Orka Desktop** integrates with other cloud based, licensed MacStadium products, like **Orka**. For example, an image built and tested with **Orka Desktop** can be uploaded to a Container Repository that is shared with an Orka cloud instance, using this integrated tool. The ability to publish local images to the Orka cloud means users can develop locally and deploy globally - offering flexibility, scalability, and an on-ramp to use MacStadium products more effectively.
 
-> 🗒️ **NOTE**
-> 
-> Users can publish any image to a container registry, for example, GitHub Packages or DockerHub and then pull it into the **Orka Cluster**.
+<Note>
+  Users can publish any image to a container registry, for example, GitHub Packages or DockerHub and then pull it into the **Orka Cluster**.
+</Note>
 
 <Note>
   Orka Desktop is available from the following locations:
@@ -22,21 +22,24 @@ zendesk_id: 28396626048667
   - Homebrew: `brew install orka-desktop`
 </Note>
 
-> 📘 **Orka Desktop Requirements**
-> 
-> Apple M1 with 8GB RAM, and 50GB disk space
-> 
-> macOS X 14.0+ (Sonoma)
-> 
-> macOS X 13.0+ (Ventura)
+<Note>
+  **Orka Desktop Requirements**
 
-> 📘 **Registry Requirements**
-> 
->   1. Pull - Clients are able to pull from the registry
->   2. Push - Clients are able to push to the registry
->   3. Content Discovery - Clients are able to list or otherwise query the content stored in the registry
->   4. Content Management - Clients are able to control the full life-cycle of the content stored in the registry
-> 
+  Apple M1 with 8GB RAM, and 50GB disk space
+
+  macOS X 14.0+ (Sonoma)
+
+  macOS X 13.0+ (Ventura)
+</Note>
+
+<Note>
+  **Registry Requirements**
+
+  1. Pull - Clients are able to pull from the registry
+  2. Push - Clients are able to push to the registry
+  3. Content Discovery - Clients are able to list or otherwise query the content stored in the registry
+  4. Content Management - Clients are able to control the full life-cycle of the content stored in the registry
+</Note>
 
 
 All registries conforming to this specification must support all APIs in the Pull category.
@@ -64,11 +67,10 @@ Users can deploy a VM using a compatible image from a private or public registry
 
 3. Use the VM.
 
-> 🗒️ **NOTES**
-> 
->   * IPSW (Apple Software/Firmware) is a file format used in macOS firmware for devices equipped with Apple silicon.
->   * There is also the option to pull the latest IPSW directly from Apple’s servers, which is detailed in the Other IPSW Options section.
-> 
+<Note>
+  - IPSW (Apple Software/Firmware) is a file format used in macOS firmware for devices equipped with Apple silicon.
+  - There is also the option to pull the latest IPSW directly from Apple’s servers, which is detailed in the Other IPSW Options section.
+</Note>
 
 
 ## Downloading Orka Desktop
@@ -97,19 +99,18 @@ _Confirmation Box_
 ![a37f0ea-image.png](/images/attachments/28396594767899.png)  
 
 
-🗒️ **NOTES**
-
-```
- * In this example, the new VM is called New Name Here, and at the same time, that name appears on the left-hand side of the screen, under the list of available Virtual Machines.
- * The VM is now in a pending installation state.
-```
+<Note>
+  - In this example, the new VM is called New Name Here, and at the same time, that name appears on the left-hand side of the screen, under the list of available Virtual Machines.
+  - The VM is now in a pending installation state.
+</Note>
   5. If a user wants to select an existing IPSW file, then select **Other** from the dropdown menu.  
 ![af3c9aa-image \(1\).png](/images/attachments/28396594771611.png)  
 
 
 _Other (to select from an existing IPSW file)_  
-🗒️ **NOTE  
-** Selecting the **Other** dropdown opens a folder, which the user can pick the existing IPSW file to install.
+<Note>
+  Selecting the **Other** dropdown opens a folder, which the user can pick the existing IPSW file to install.
+</Note>
 
   6. If a user does not have a local IPSW file to use for the new VM, then select Download Latest, to get the latest files from Apple.  
 ![fa81c57-image.png](/images/attachments/28396625948571.png)  
@@ -128,9 +129,9 @@ _Image Data Location_
 
 
 
-> 🗒️ **NOTE**
-> 
-> When the install completes, there is a new VM available on the Orka Desktop, which can be used to Start, Pause, Resume, Stop, or Console into.
+<Note>
+  When the install completes, there is a new VM available on the Orka Desktop, which can be used to Start, Pause, Resume, Stop, or Console into.
+</Note>
 
 ## Creating a New Virtual Machine (Pull from OCI Image)
 
@@ -180,13 +181,12 @@ _VM Starting_
 
 **NOTE** : Starting a VM for the first time may take several minutes.
 
-> 🗒️ **NOTES**
-> 
->   * This VM might be configured to run a different version of macOS from your host, so users can test the same software in two different environments. Note that you can only use OSs in VMs that are more recent than the OS running on the host.
->   * Users may install Xcode, then use it as a build machine for iOS apps.
->   * IT Admins can test Mobile Device Management (MDM) profiles using VMs, which can be easily done without maintaining several Mac mini machines. MDM profile testing can be performed on a VM that was created by Orka Desktop.
->   * Apple has limited the ability to sign into iCloud with an Apple ID within a VM.
-> 
+<Note>
+  - This VM might be configured to run a different version of macOS from your host, so users can test the same software in two different environments. Note that you can only use OSs in VMs that are more recent than the OS running on the host.
+  - Users may install Xcode, then use it as a build machine for iOS apps.
+  - IT Admins can test Mobile Device Management (MDM) profiles using VMs, which can be easily done without maintaining several Mac mini machines. MDM profile testing can be performed on a VM that was created by Orka Desktop.
+  - Apple has limited the ability to sign into iCloud with an Apple ID within a VM.
+</Note>
 
 
 ## Stop a VM
@@ -266,11 +266,10 @@ Use to set log file location, VM directory, and other information.
 
 ![f0d07cb-image.png](/images/attachments/28396594835099.png)
 
-> 👍 **Tips**
-> 
->   * Orka Desktop automatically starts a Console (screen share) session with the VM when Start is selected.
->   * Managing and debugging issues with the VMs is made simple with a comprehensive list of actions available, including the ability to view and traverse log files and other artifacts.
-> 
+<Tip>
+  - Orka Desktop automatically starts a Console (screen share) session with the VM when Start is selected.
+  - Managing and debugging issues with the VMs is made simple with a comprehensive list of actions available, including the ability to view and traverse log files and other artifacts.
+</Tip>
 
 
 ## Other IPSW Options

--- a/orka/orka-on-aws-and-on-prem/orka-on-aws-getting-started.mdx
+++ b/orka/orka-on-aws-and-on-prem/orka-on-aws-getting-started.mdx
@@ -39,18 +39,18 @@ The new AMI is compatible with Orka 3.5 and all EC2 Apple Silicon Mac instance t
 
 By default:
 
-```
-  * The NVMe disk is used for Orka storage of VM and image data on M4 instances only
+- The NVMe disk is used for Orka storage of VM and image data on M4 instances only
+- Autologin is enabled for the `ec2-user`, and is required when running a Sequoia guest OS or newer
 
-  * Autologin is enabled for the `ec2-user`, and is required when running a Sequoia guest OS or newer
+<Note>
+  The `ENABLE_NVME_DISK` and `ENABLE_AUTOLOGIN` variables are **not** required. These are set to `true` by default, and either variable may be disabled if needed:
+</Note>
 
-  * **Note:** The `ENABLE_NVME_DISK` and `ENABLE_AUTOLOGIN` variables are **not** required. These are set to `true` by default, and either variable may be disabled if needed:  
-
-        
-        #!/bin/bash
-        export ENABLE_NVME_DISK=false # disable NVMe disk, use EBS storage instead
-        export ENABLE_AUTOLOGIN=false # disable autologin for ec2-user on bootstrap
-        /usr/local/bin/bootstrap-orka <eks-cluster-name> <vpc-region> <orka-license-key>
+```bash
+#!/bin/bash
+export ENABLE_NVME_DISK=false # disable NVMe disk, use EBS storage instead
+export ENABLE_AUTOLOGIN=false # disable autologin for ec2-user on bootstrap
+/usr/local/bin/bootstrap-orka <eks-cluster-name> <vpc-region> <orka-license-key>
 ```
   * Networking
     * Apple Silicon nodes don’t have a direct tie-in to the traditional k8s networking stack. With Orka, we provide a private network, expose certain ports, and require NATing for access. We do provide modes for network isolation and internet isolation. We provide documentation below for how to expose Orka services outside of the cluster. As of Orka 3.5.0, we also support [bridge networking mode](/orka/orka-on-aws-and-on-prem/using-bridge-networking-with-orka-350), enabling the ability to get an IP on a subnet in your VPC.

--- a/orka/orka-on-aws-and-on-prem/using-bridge-networking-with-orka-350.mdx
+++ b/orka/orka-on-aws-and-on-prem/using-bridge-networking-with-orka-350.mdx
@@ -10,7 +10,7 @@ zendesk_id: 41316947194139
 
 Bridged networking allows Orka VMs running Orka 3.5.0 to connect directly to a physical network as a native device, receiving their own IP address from the network’s DHCP server. This enables direct communication with other network devices and services without the use of NAT, and is configurable automatically using Orka alongside your existing DHCP server.
 
-### Getting started:
+## Getting started
 
 To set up bridge networking in your Orka on-prem cluster, you will need to set the following variables in your host’s `cluster.yml` file:
 

--- a/orka/orka-upgrades-and-release-notes/orka-30-release-notes.mdx
+++ b/orka/orka-upgrades-and-release-notes/orka-30-release-notes.mdx
@@ -326,11 +326,11 @@ xattr -d com.apple.quarantine '/Applications/Xcode.app'
 ```
 ## How to upgrade
 
-> **Scheduled maintenance window required**
-> 
-> Orka 3.0.0 is a virtualization and orchestration layer upgrade. For more information, see [Orka Upgrades](/orka/orka-upgrades-and-release-notes/orka-upgrades#virtualization-and-orchestration-layer-upgrades-kubernetes-docker-or-linux).
-> 
-> **This release requires a maintenance window of up to 3 hours depending on the size of the cluster.**
+<Warning>
+  Orka 3.0.0 is a virtualization and orchestration layer upgrade. For more information, see [Orka Upgrades](/orka/orka-upgrades-and-release-notes/orka-upgrades#virtualization-and-orchestration-layer-upgrades-kubernetes-docker-or-linux).
+
+  This release requires a maintenance window of up to 3 hours depending on the size of the cluster.
+</Warning>
 
   1. Submit a ticket through the [MacStadium portal](https://portal.macstadium.com/).
   2. Schedule a time for the maintenance window that works for you through the link provided in the ticket.  

--- a/orka/orka-upgrades-and-release-notes/orka-31-release-notes.mdx
+++ b/orka/orka-upgrades-and-release-notes/orka-31-release-notes.mdx
@@ -9,9 +9,9 @@ Released: May 9, 2024
 
 
 
-> **IMPORTANT**
-> 
-> Always ensure that your cluster, Orka tools and integrations, and Orka VM Tools run matching versions. For example, the respective available 3.x versions.
+<Warning>
+  Always ensure that your cluster, Orka tools and integrations, and Orka VM Tools run matching versions. For example, the respective available 3.x versions.
+</Warning>
 
 # Orka v3.1.0
 
@@ -141,11 +141,11 @@ xattr -d com.apple.quarantine '/Applications/Xcode.app'
 ```
 ## How to upgrade
 
-> **Scheduled maintenance window required**
-> 
-> Orka 3.1.0 is a new Orka release upgrade. For more information, see [Orka Upgrades](/orka/orka-upgrades-and-release-notes/orka-upgrades#virtualization-and-orchestration-layer-upgrades-kubernetes-docker-or-linux).
-> 
-> **This release requires a maintenance window of up to 3 hours depending on the size of the cluster.**
+<Warning>
+  Orka 3.1.0 is a new Orka release upgrade. For more information, see [Orka Upgrades](/orka/orka-upgrades-and-release-notes/orka-upgrades#virtualization-and-orchestration-layer-upgrades-kubernetes-docker-or-linux).
+
+  This release requires a maintenance window of up to 3 hours depending on the size of the cluster.
+</Warning>
 
   1. Submit a ticket through the [MacStadium portal](https://portal.macstadium.com/).
   2. Schedule a time for the maintenance window that works for you through the link provided in the ticket.  

--- a/orka/orka-upgrades-and-release-notes/orka-32-release-notes.mdx
+++ b/orka/orka-upgrades-and-release-notes/orka-32-release-notes.mdx
@@ -91,9 +91,9 @@ A recent upstream change to the ARC project caused previously used variables tha
 
 Orka Cluster version 3.2 introduces a new feature, Scheduled Caching, and also provides support for Sequoia 15.0 VM images.
 
-> 🗒️**NOTE**
-> 
-> Sequoia support is dependent on requesting that some or all nodes are upgraded to Sequoia 15.0 in the upgrade request service ticket.
+<Note>
+  Sequoia support is dependent on requesting that some or all nodes are upgraded to Sequoia 15.0 in the upgrade request service ticket.
+</Note>
 
 ## Scheduled Caching
 
@@ -101,9 +101,9 @@ Scheduled caching enables users to configure their Orka clusters to proactively 
 
 The scheduled caching feature requires planning for target nodes and optimal maintenance window periods. There is a noticeable impact on VMs running during image cache downloads (particularly on I/O operations). It is best to avoid caching while scheduling running builds unless the image size is smaller < 16GB.
 
-> 🗒️**NOTE**
-> 
-> The cache downloads directly from OCI repositories are currently slower than normal image download times by approximately 2-3x. For the beta release it is better to cache from NFS stores. If necessary, pull repo images down to NFS stores and then begin cache downloads to cluster nodes. Caching an image to more than five nodes simultaneously also adds delay to cache download completion time.
+<Note>
+  The cache downloads directly from OCI repositories are currently slower than normal image download times by approximately 2-3x. For the beta release it is better to cache from NFS stores. If necessary, pull repo images down to NFS stores and then begin cache downloads to cluster nodes. Caching an image to more than five nodes simultaneously also adds delay to cache download completion time.
+</Note>
 
 ## Sequoia Support
 
@@ -115,18 +115,15 @@ While upgrading Orka Cluster to release 3.2, MacStadium will also upgrade the cl
 
 ## Upgrading
 
-> **WARNING**
-> 
->   * A scheduled maintenance window is required.
->   * This release requires a maintenance window of up to 3 hours depending on the size of the cluster.
-> 
+<Warning>
+  - A scheduled maintenance window is required.
+  - This release requires a maintenance window of up to 3 hours depending on the size of the cluster.
+</Warning>
 
-
-> **🗒️NOTES**
-> 
->   * Orka 3.2.0 is a new Orka release upgrade. For more information, see [Orka Upgrades](/orka/orka-upgrades-and-release-notes/orka-upgrades#virtualization-and-orchestration-layer-upgrades-kubernetes-docker-or-linux).
->   * For customers who have not yet upgraded to Orka Cluster 3.0.0 please read the [migration guide](/orka/orka-cluster-migration-from-24-3x/24x-to-300-after-the-migration) before submitting a ticket.
-> 
+<Note>
+  - Orka 3.2.0 is a new Orka release upgrade. For more information, see [Orka Upgrades](/orka/orka-upgrades-and-release-notes/orka-upgrades#virtualization-and-orchestration-layer-upgrades-kubernetes-docker-or-linux).
+  - For customers who have not yet upgraded to Orka Cluster 3.0.0 please read the [migration guide](/orka/orka-cluster-migration-from-24-3x/24x-to-300-after-the-migration) before submitting a ticket.
+</Note>
 
 
   1. Submit a ticket through the [MacStadium portal](https://idp.macstadium.com/login?scope=aws.cognito.signin.user.admin+email+openid+phone+profile&response_type=code&client_id=os594upi12pn9ab16hmtk0akp&redirect_uri=https%3A%2F%2Fportal.macstadium.com%2Foauth%2Fredirect&state=eyJsYXN0VmlzaXRlZFVybCI6Ii8ifQ).

--- a/orka/orka-upgrades-and-release-notes/orka-35-release-notes.mdx
+++ b/orka/orka-upgrades-and-release-notes/orka-35-release-notes.mdx
@@ -158,11 +158,8 @@ kubectl config set-context orka --namespace=orka-default
 
   * Reduced noise and fixed behavior in non-default namespaces
 
-```
-* Orka no longer tries to process unsupported ECR refresh jobs when new namespaces are created
-
-* The image caching state is updated correctly when caching an already-cached image after a node moves to a different namespace
-```
+  - Orka no longer tries to process unsupported ECR refresh jobs when new namespaces are created
+  - The image caching state is updated correctly when caching an already-cached image after a node moves to a different namespace
 ## Bug fixes
 
   * macOS Tahoe 26.0 compatibility fixes for image deletion, copying, and tagging

--- a/orka/orka3-cli-reference/oci-registry-integration.mdx
+++ b/orka/orka3-cli-reference/oci-registry-integration.mdx
@@ -155,7 +155,7 @@ orka3 vm deploy -i ghcr.io/my-organization/orka-images/orka-arm:14.0
 
 The state of a running VM can be saved and pushed to an OCI-compatible registry. This operation is applicable only to Apple silicon-based VMs.
 
-For more information, see the [VM Lifecycle Management](https://www.claudeusercontent.com/?domain=claude.ai&errorReportingMode=parent#) article.
+For more information, see the [VM Lifecycle Management](/orka/orka3-cli-reference/vm-lifecycle-management) article.
 
 **Caching OCI Images**
 

--- a/orka/orka3-cli-reference/output-formats-and-getting-help.mdx
+++ b/orka/orka3-cli-reference/output-formats-and-getting-help.mdx
@@ -63,11 +63,10 @@ Many Orka CLI commands support multiple output formats to suit different use cas
 
 **Available Output Formats**
 
-Format | Flag | Description | Best For  
----|---|---|---  
-**Table** |  `--output table`  
-(default) | Human-readable table with essential information | Terminal viewing, quick status checks  
-**Wide** | `--output wide` | Extended table with additional columns and details | Detailed troubleshooting, viewing all properties  
+Format | Flag | Description | Best For
+---|---|---|---
+**Table** | `--output table` (default) | Human-readable table with essential information | Terminal viewing, quick status checks
+**Wide** | `--output wide` | Extended table with additional columns and details | Detailed troubleshooting, viewing all properties
 **JSON** | `--output json` | Machine-readable JSON format | Scripting, automation, parsing with jq  
   
 **Using Output Formats**

--- a/orka/orka3-cli-reference/vm-lifecycle-management.mdx
+++ b/orka/orka3-cli-reference/vm-lifecycle-management.mdx
@@ -318,7 +318,9 @@ orka3 vm resume small-ventura-vm --namespace orka-test
 
 (Intel-only) Revert a VM to the latest state of its image. This operation restarts the VM.
 
-**🚧 CAUTION:** This operation cannot be undone. Any unsaved or uncommitted data will be lost and unable to be retrieved.
+<Warning>
+  This operation cannot be undone. Any unsaved or uncommitted data will be lost and unable to be retrieved.
+</Warning>
 
 **Syntax:**
     

--- a/remote-desktop-vdi/operational-guides/troubleshooting-quick-reference.mdx
+++ b/remote-desktop-vdi/operational-guides/troubleshooting-quick-reference.mdx
@@ -46,7 +46,21 @@ What you see: `deploy.yml` playbook fails with error messages
 
 Quick diagnostic:
 
-`ansible-playbook -i dev/inventory deploy.yml \ -e "vm_group=test" \ -e "desired_vms=1" \ -e "vm_image=<image-name>" \ -vvv ansible-playbook -i dev/inventory pull_image.yml \ -e "remote_image_name=<image-name>" \ -v ansible hosts -i dev/inventory -m shell -a "df -h /var/orka" ansible hosts -i dev/inventory -m shell -a "orka-engine --version"`
+```bash
+ansible-playbook -i dev/inventory deploy.yml \
+  -e "vm_group=test" \
+  -e "desired_vms=1" \
+  -e "vm_image=<image-name>" \
+  -vvv
+
+ansible-playbook -i dev/inventory pull_image.yml \
+  -e "remote_image_name=<image-name>" \
+  -v
+
+ansible hosts -i dev/inventory -m shell -a "df -h /var/orka"
+
+ansible hosts -i dev/inventory -m shell -a "orka-engine --version"
+```
 
 Likely causes and solutions:
 
@@ -68,7 +82,18 @@ What you see: Deployment succeeds but VMs show "Stopped" or error status
 
 Quick diagnostic:
 
-`ansible-playbook -i dev/inventory list.yml | grep <vm-name> ansible-playbook -i dev/inventory vm.yml \ -e "vm_name=<vm-name>" \ -e "desired_state=running" \ -v ssh admin@<host-ip> sudo log show --predicate 'process == "orka-engine"' --last 30m | grep -i error ssh admin@<host-ip> orka-engine vm list <vm-name> --format json`
+```bash
+ansible-playbook -i dev/inventory list.yml | grep <vm-name>
+
+ansible-playbook -i dev/inventory vm.yml \
+  -e "vm_name=<vm-name>" \
+  -e "desired_state=running" \
+  -v
+
+ssh admin@<host-ip> sudo log show --predicate 'process == "orka-engine"' --last 30m | grep -i error
+
+ssh admin@<host-ip> orka-engine vm list <vm-name> --format json
+```
 
 #### Likely causes and solutions:
 
@@ -88,7 +113,11 @@ What you see:**** Requested 10 VMs but only 7 deployed, or deployment stopped pa
 
 Quick diagnostic:
 
-`ansible-playbook -i dev/inventory list.yml -e "vm_group=<group>" | grep <group> | wc -l ansible hosts -i dev/inventory -m shell -a "top -l 1 | head -20"`
+```bash
+ansible-playbook -i dev/inventory list.yml -e "vm_group=<group>" | grep <group> | wc -l
+
+ansible hosts -i dev/inventory -m shell -a "top -l 1 | head -20"
+```
 
 **Likely causes and solutions:**
 
@@ -107,7 +136,18 @@ Partial playbook failure | Playbook shows some failed tasks | Review errors in v
 
 **Quick diagnostic:**
 
-`ansible-playbook -i dev/inventory vm.yml \ -e "vm_name=<vm-name>" \ -e "desired_state=absent" \ -vvv ansible-playbook -i dev/inventory list.yml | grep <vm-name> ssh admin@<host-ip> orka-engine vm stop <vm-name> --force orka-engine vm delete <vm-name> ssh admin@<host-ip> ps aux | grep <vm-name>`
+```bash
+ansible-playbook -i dev/inventory vm.yml \
+  -e "vm_name=<vm-name>" \
+  -e "desired_state=absent" \
+  -vvv
+
+ansible-playbook -i dev/inventory list.yml | grep <vm-name>
+
+ssh admin@<host-ip> orka-engine vm stop <vm-name> --force
+ssh admin@<host-ip> orka-engine vm delete <vm-name>
+ssh admin@<host-ip> ps aux | grep <vm-name>
+```
 
 **Likely causes and solutions:**
 
@@ -129,7 +169,20 @@ What you see: VMs show as "Unregistered" in Citrix Cloud Console → Monitor →
 
 Quick diagnostic:
 
-`ansible-playbook -i dev/inventory list.yml | grep <vm-name> ssh admin@<host-ip> open vnc://<vm-ip>:5900 // Navigate to: System Preferences → Citrix VDA // Should show: "Registered" with Cloud Connector details // Test network connectivity from the VM // From the VM Terminal: ping <cloud-connector-ip> curl https://api.cloud.com // Check VDA service logs // On the VM: Console.app → Search for "Citrix"`
+```bash
+ansible-playbook -i dev/inventory list.yml | grep <vm-name>
+
+# Connect via VNC to inspect VDA status:
+# Navigate to: System Preferences → Citrix VDA
+# Should show: "Registered" with Cloud Connector details
+
+# Test network connectivity from the VM (run from VM Terminal):
+ping <cloud-connector-ip>
+curl https://api.cloud.com
+
+# Check VDA service logs:
+# On the VM: Console.app → Search for "Citrix"
+```
 
 **Likely causes and solutions:**
 

--- a/remote-desktop-vdi/orka-for-vdi-deployment/business-outcomes-use-cases.mdx
+++ b/remote-desktop-vdi/orka-for-vdi-deployment/business-outcomes-use-cases.mdx
@@ -22,7 +22,7 @@ Physical Mac endpoints are vulnerable to theft, loss, and unauthorized access. T
 
 Organizations with data sovereignty requirements face additional challenges ensuring that sensitive information remains within specific geographic boundaries.
 
-_"We have a need to have a United States based VDI solution for our international contractors who need to be able to access data that can only reside and be accessed within the United States." _\-- U.S.-based healthcare technology leader
+_"We have a need to have a United States based VDI solution for our international contractors who need to be able to access data that can only reside and be accessed within the United States."_ — U.S.-based healthcare technology leader
 
 **Solution:** With Citrix + Orka, all data resides in MacStadium's SOC 2 and ISO 27001 compliant data centers. No local storage means zero risk from lost or stolen devices, and you control exactly where your intellectual property lives.
 
@@ -85,7 +85,7 @@ Media rendering, complex iOS builds, AI/ML workloads, and other compute-intensiv
 
 ### Why Choose MacStadium for Citrix VDI?
 
-**Genuine Apple Hardware:** MacStadium provides access to authentic Mac mini and Studio hardware in cloud compute environments—no emulation, no compromises. [View available models](https://www.macstadium.com/bare-metal-mac "https://www.macstadium.com/bare-metal-mac").
+**Genuine Apple Hardware:** MacStadium provides access to authentic Mac mini and Studio hardware in cloud compute environments—no emulation, no compromises. [View available models](https://www.macstadium.com/bare-metal-mac).
 
 **Proven Citrix Technology:** Leverage HDX protocol, established security posture, SSO/MFA integration, and the familiar Citrix administration experience your team already knows.
 

--- a/remote-desktop-vdi/orka-for-vdi-deployment/citrix-daas-configuration.mdx
+++ b/remote-desktop-vdi/orka-for-vdi-deployment/citrix-daas-configuration.mdx
@@ -33,42 +33,29 @@ Machine Catalogs are logical groupings of virtual machines in Citrix. When using
 
   3. **Select catalog type:**
 
-```
- * Choose **"Remote PC Access"**
+     - Choose **"Remote PC Access"**
+     - This type is designed for physical Mac devices and works with Citrix VDA for macOS
+     - Select **"Machines that are not power managed"** (Orka manages the VM lifecycle)
 
- * This type is designed for physical Mac devices and works with Citrix VDA for macOS
-
- * Select **"Machines that are not power managed"** (Orka manages the VM lifecycle)
-```
   4. **Configure Machine Catalog settings:**
 
-```
- * **Catalog name:** Use a descriptive name like "Orka-macOS-Sonoma-Standard" or "MacStadium-VDI-Finance"
+     - **Catalog name:** Use a descriptive name like "Orka-macOS-Sonoma-Standard" or "MacStadium-VDI-Finance"
+     - **Description:** Document the purpose, OS version, and hardware specs (e.g., "macOS Sonoma on M2 Mac mini, 16GB RAM, for finance team")
+     - **Session type:** Single-session (each user gets their own desktop)
+     - **User assignment:** Choose based on your use case:
+       - **Random (pooled):** Users get any available desktop (non-persistent)
+       - **Static (dedicated):** Users get the same desktop every session (persistent)
 
- * **Description:** Document the purpose, OS version, and hardware specs (e.g., "macOS Sonoma on M2 Mac mini, 16GB RAM, for finance team")
-
- * **Session type:** Single-session (each user gets their own desktop)
-
- * **User assignment:** Choose based on your use case:
-
-   * **Random (pooled):** Users get any available desktop (non-persistent)
-
-   * **Static (dedicated):** Users get the same desktop every session (persistent)
-```
   5. **Machine accounts:**
 
-```
- * For non-domain-joined Macs, select **"No, do not add to Active Directory"**
+     - For non-domain-joined Macs, select **"No, do not add to Active Directory"**
+     - This requires Rendezvous protocol for connectivity
 
- * This requires Rendezvous protocol for connectivity
-```
   6. **Add machines:**
 
-```
- * You'll add machines to the catalog after deploying VMs with Citrix VDA
+     - You'll add machines to the catalog after deploying VMs with Citrix VDA
+     - Machines register automatically using the enrollment token
 
- * Machines register automatically using the enrollment token
-```
 **Machine Catalog naming strategy:**
 
 Use a consistent naming pattern that reflects:
@@ -100,38 +87,26 @@ An enrollment token is critical for connecting your Orka-hosted VMs to Citrix Cl
 
   4. **Configure token settings:**
 
-```
- * **Token name:** Descriptive identifier (e.g., "Orka-Finance-Q1-2026")
+     - **Token name:** Descriptive identifier (e.g., "Orka-Finance-Q1-2026")
+     - **Expiration:** Set based on your deployment timeline
+       - 12 hours: For immediate testing
+       - 7 days: Standard deployment window
+       - 30 days: Ongoing/phased rollouts
+     - **Number of uses:**
+       - Unlimited (default): Token can register multiple VMs
+       - Limited: Specify exact number if needed for strict control
 
- * **Expiration:** Set based on your deployment timeline
-
-   * 12 hours: For immediate testing
-
-   * 7 days: Standard deployment window
-
-   * 30 days: Ongoing/phased rollouts
-
- * **Number of uses:**
-
-   * Unlimited (default): Token can register multiple VMs
-
-   * Limited: Specify exact number if needed for strict control
-```
   5. **Copy the token immediately:**
 
-```
- * The token is displayed only once
+     - The token is displayed only once
+     - Store it securely in your Ansible Vault
+     - If lost, generate a new token (old token remains valid until expiration)
 
- * Store it securely in your Ansible Vault
-
- * If lost, generate a new token (old token remains valid until expiration)
-```
 **Adding a token to Ansible configuration:**
 
 Update your Ansible Vault file:
-    
-    
-```
+
+```yaml
 vault_citrix_enrollment_token: "your-actual-token-here"
 vault_citrix_customer_id: "YOUR_CUSTOMER_ID"
 ```
@@ -168,93 +143,60 @@ Delivery Groups control which users can access which machines and define the use
 
   3. **Select machines:**
 
-```
- * Choose the Machine Catalog created earlier
+     - Choose the Machine Catalog created earlier
+     - Specify how many machines to include (can be all or a subset)
 
- * Specify how many machines to include (can be all or a subset)
-```
   4. **Configure users:**
 
-```
- * **Add users or groups** who should have access
+     - **Add users or groups** who should have access
+     - Options include:
+       - Active Directory users/groups (if domain-joined)
+       - Azure AD users/groups
+       - Individual user accounts
+     - For testing, you can use "Allow unauthenticated users" (Note: This is **not recommended** for production)
 
- * Options include:
-
-   * Active Directory users/groups (if domain-joined)
-
-   * Azure AD users/groups
-
-   * Individual user accounts
-
- * For testing, you can use "Allow unauthenticated users" (Note: This is **not recommended** for production)
-```
   5. **Delivery Group name and settings:**
 
-```
- * Name: Descriptive, for example: "Finance-macOS-VDI" or "Engineering-Sonoma-Desktops"
+     - Name: Descriptive, for example: "Finance-macOS-VDI" or "Engineering-Sonoma-Desktops"
+     - Display name: What users see in Citrix Workspace (e.g., "macOS Finance Desktop")
+     - Description: Document purpose and access requirements
+     - Time zone: Set to match user locations or leave as client time zone
 
- * Display name: What users see in Citrix Workspace (e.g., "macOS Finance Desktop")
-
- * Description: Document purpose and access requirements
-
- * Time zone: Set to match user locations or leave as client time zone
-```
   6. **Configure desktop assignment:**
 
-```
- * For pooled (random) catalogs: Users get any available desktop
+     - For pooled (random) catalogs: Users get any available desktop
+     - For dedicated (static) catalogs: Users are permanently assigned to specific desktops
 
- * For dedicated (static) catalogs: Users are permanently assigned to specific desktops
-```
   7. **Application and desktop delivery:**
 
-```
- * Published Desktop: Users access a full macOS desktop
+     - Published Desktop: Users access a full macOS desktop
+     - Published Applications: Specific apps published to users
+     - For Citrix + Orka VDI, select the "Add Desktop" delivery type
 
- * Published Applications: Specific apps published to users
-
- * For Citrix + Orka VDI, select the "Add Desktop" delivery type
-```
   8. **Session policies:**
 
-```
- * Configure session timeout settings
+     - Configure session timeout settings
+     - Set idle session behavior
+     - Define reconnection policies
+     - Enable or disable features like printing, clipboard, USB redirection
 
- * Set idle session behavior
-
- * Define reconnection policies
-
- * Enable or disable features like printing, clipboard, USB redirection
-```
 **Access policy considerations:**
 
   * **Authentication method:** How users prove their identity
+    - Active Directory (traditional)
+    - Azure AD / Okta / other SAML providers
+    - Multi-factor authentication (MFA) support
 
-```
-* Active Directory (traditional)
-
-* Azure AD / Okta / other SAML providers
-
-* Multi-factor authentication (MFA) support
-```
   * **Access from:** Define where users can connect from
+    - Internal network only
+    - Remote access via Citrix Gateway
+    - Both internal and external
 
-```
-* Internal network only
-
-* Remote access via Citrix Gateway
-
-* Both internal and external
-```
   * **Device posture:** (Optional) Restrict based on device compliance
+    - Managed devices only
+    - Endpoint security requirements
+    - Operating system versions
 
-```
-* Managed devices only
-
-* Endpoint security requirements
-
-* Operating system versions
-```
 **Multiple Delivery Groups**
 
 Consider creating several Delivery Groups from the same Machine Catalog:
@@ -316,22 +258,16 @@ Rendezvous is typically enabled by default for Citrix DaaS environments with non
 
   4. Configure Rendezvous settings:
 
-```
- * HDX Adaptive Transport: Set to "Preferred" or "Server Only"
+     - HDX Adaptive Transport: Set to "Preferred" or "Server Only"
+     - Rendezvous Protocol: Enable
+     - WebSocket connections: Allow
 
- * Rendezvous Protocol: Enable
-
- * WebSocket connections: Allow
-```
   5. On the VDA side:
 
-```
- * The VDA automatically detects Rendezvous capability
+     - The VDA automatically detects Rendezvous capability
+     - Establishes outbound connection to `*.*.nssvc.net`
+     - Maintains persistent WebSocket connection for HDX session brokering
 
- * Establishes outbound connection to `*.*.nssvc.net`
-
- * Maintains persistent WebSocket connection for HDX session brokering
-```
 **Network requirements for Rendezvous**
 
 Ensure VMs have outbound access to:
@@ -339,12 +275,9 @@ Ensure VMs have outbound access to:
   * `*.*.nssvc.net` on TCP/UDP port 443
 
   * If your firewall requires specific subdomains, use:
+    - `*.g.nssvc.net` (Gateway Service)
+    - `*.c.nssvc.net` (Control plane)
 
-```
-* `*.g.nssvc.net` (Gateway Service)
-
-* `*.c.nssvc.net` (Control plane)
-```
 No inbound ports required on the VDA when using Rendezvous (major security advantage).
 
 **Rendezvous Protocol behavior**
@@ -376,11 +309,9 @@ If you need to disable Rendezvous:
 
   3. Update VDA configuration:
 
-```
- * Disable Rendezvous in VDA settings
+     - Disable Rendezvous in VDA settings
+     - Point VDA to StoreFront servers instead of Cloud Connectors
 
- * Point VDA to StoreFront servers instead of Cloud Connectors
-```
 Keeping Rendezvous enabled is recommended for simplicity and functionality.
 
 **Testing Rendezvous connectivity**
@@ -425,15 +356,11 @@ Preparation steps:
 
   1. **Download Citrix VDA for macOS:**
 
-```
- * Access Citrix Downloads portal
+     - Access Citrix Downloads portal
+     - Locate "Citrix VDA for macOS" package
+     - Download latest stable version
+     - Verify package integrity
 
- * Locate "Citrix VDA for macOS" package
-
- * Download latest stable version
-
- * Verify package integrity
-```
   2. **Install Microsoft .NET Runtime 8.0:**
 
      * Required dependency for VDA enrollment and registration
@@ -443,83 +370,65 @@ Preparation steps:
      * Reference: [Install .NET on macOS - .NET](https://learn.microsoft.com/en-us/dotnet/core/install/macos)
 
      * Install on base image or individual VMs
+
   3. **Prepare installation parameters:**
 
-```
- * Citrix enrollment token
+     - Citrix enrollment token
+     - Customer ID
+     - Delivery controller addresses or cloud endpoint
+     - Network configuration settings
 
- * Customer ID
-
- * Delivery controller addresses or cloud endpoint
-
- * Network configuration settings
-```
 **Manual deployment approach**
 
 For pilot deployments or troubleshooting:
 
   1. **Deploy test VM from base image:**
 
-```
- * Use Orka Engine to create a VM from a macOS base image
-       
+     - Use Orka Engine to create a VM from a macOS base image
+
+       ```bash
        # Plan deployment (dry-run)
        ansible-playbook -i inventory deploy.yml \
          -e "vm_group=citrix-vda-test" \
          -e "desired_vms=1" \
          --tags plan
-       
+
        # Execute deployment
        ansible-playbook -i inventory deploy.yml \
          -e "vm_group=citrix-vda-test" \
          -e "desired_vms=1"
+       ```
 
- * Allocate appropriate VM resources (CPU, RAM, storage)
+     - Allocate appropriate VM resources (CPU, RAM, storage)
+     - Attach VM to correct network bridge
+     - Start VM and establish SSH access
 
- * Attach VM to correct network bridge
-
- * Start VM and establish SSH access
-```
   2. **Copy VDA installer to VM:**
 
-```
- * Transfer CitrixVDA.pkg to VM via SCP or shared storage
+     - Transfer CitrixVDA.pkg to VM via SCP or shared storage
+     - Also copy .NET Runtime installer if not in base image
 
- * Also copy .NET Runtime installer if not in base image
-```
   3. **Install prerequisites:**
 
-```
- * Install .NET Runtime 8.0
+     - Install .NET Runtime 8.0
+     - Verify installation successful
+     - Restart if required
 
- * Verify installation successful
-
- * Restart if required
-```
   4. **Install Citrix VDA:**
 
-```
- * Run VDA installer package with administrative privileges
+     - Run VDA installer package with administrative privileges
+     - Provide enrollment token during installation (note: enrollment can take 5-10 minutes)
+     - Specify Citrix Cloud customer ID
+     - Configure network settings (Rendezvous enabled if non-domain-joined)
+     - Complete installation and restart VM
 
- * Provide enrollment token during installation (note: enrollment can take 5-10 minutes)
-
- * Specify Citrix Cloud customer ID
-
- * Configure network settings (Rendezvous enabled if non-domain-joined)
-
- * Complete installation and restart VM
-```
   5. **Initial configuration:**
 
-```
- * VDA service starts automatically after installation
+     - VDA service starts automatically after installation
+     - Verify VDA service is running
+     - Check log files for any errors
+     - Confirm network connectivity to Citrix Cloud endpoints
 
- * Verify VDA service is running
-
- * Check log files for any errors
-
- * Confirm network connectivity to Citrix Cloud endpoints
-```
 **Automated deployment approach**
 
 For scalable deployments, automate VDA installation via Ansible.
@@ -528,28 +437,25 @@ For scalable deployments, automate VDA installation via Ansible.
 
   1. Deploy a clean VM using Orka Engine
 
+     ```bash
+     ansible-playbook -i inventory.ini create_orka_vm.yml \
+       -e "vm_name=quick-vm" \
+       -e "image_source=ghcr.io/macstadium/orka-images/sonoma:latest"
+     ```
 
+  2. Install .NET Runtime 8.0
 
-    
-    
-```
-ansible-playbook -i inventory.ini create_orka_vm.yml \
-  -e "vm_name=quick-vm" \
-  -e "image_source=ghcr.io/macstadium/orka-images/sonoma:latest"
-```
-2. Install .NET Runtime 8.0
+  3. Install Citrix VDA (without enrolling)
 
-3. Install Citrix VDA (without enrolling)
+  4. Configure base settings
 
-4. Configure base settings
+  5. Commit VM to create image
 
-5. Commit VM to create image
+  6. Push image to OCI registry
 
-6. Push image to OCI registry
+  7. Deploy new VMs from this golden image
 
-7. Deploy new VMs from this golden image
-
-8. Each VM enrolls automatically on first boot using your enrollment token
+  8. Each VM enrolls automatically on first boot using your enrollment token
 
 **Installation parameters:**
 
@@ -576,17 +482,14 @@ After successful VDA deployment:
 
   * Tag image with version information
 
-  * Push to private registry 
+  * Push to private registry
 
+     ```bash
+     ansible-playbook -i inventory.ini publish_orka_image.yml \
+       -e "local_image=my-backup" \
+       -e "remote_image=myregistry.com/orka/my-image:v1"
+     ```
 
-
-    
-    
-```
-ansible-playbook -i inventory.ini publish_orka_image.yml \
-  -e "local_image=my-backup" \
-  -e "remote_image=myregistry.com/orka/my-image:v1"
-```
   * Document installed software versions
 
   * Test image deployment before marking as production-ready
@@ -631,15 +534,11 @@ Check registration status in Web Studio:
 
   4. Verify your VM appears with:
 
-```
- * Machine name (hostname)
+     - Machine name (hostname)
+     - Registration state: "Registered"
+     - Power state: "On"
+     - Session state: "Available"
 
- * Registration state: "Registered"
-
- * Power state: "On"
-
- * Session state: "Available"
-```
 **VDA logs on VM:**
 
 Examine VDA log files for registration confirmation:
@@ -647,14 +546,10 @@ Examine VDA log files for registration confirmation:
   * Log location: `/Library/Application Support/Citrix/VDA/Logs/`
 
   * Key log files:
+    - `vda.log` - Main VDA service log
+    - `registration.log` - Registration-specific events
+    - `broker.log` - Communication with Citrix Cloud
 
-```
-* `vda.log` \- Main VDA service log
-
-* `registration.log` \- Registration-specific events
-
-* `broker.log` \- Communication with Citrix Cloud
-```
 Look for successful registration messages:
 
   * "Registration successful"
@@ -715,37 +610,37 @@ Look for successful registration messages:
 **Troubleshooting commands**
 
 ##### Check VDA service status:
-    
-    
-```
+
+```bash
 ansible mac_vms -i inventory.ini \
   -m shell \
   -a "sudo launchctl list | grep citrix"
 ```
+
 ##### Restart VDA service:
-    
-    
-```
+
+```bash
 ansible mac_vms -i inventory.ini \
   -m shell \
   -a "sudo launchctl kickstart -k system/com.citrix.vda"
 ```
+
 ##### View VDA logs:
-    
-    
-```
+
+```bash
 ansible mac_vms -i inventory.ini \
   -m shell \
   -a "sudo tail -100 /Library/Application\ Support/Citrix/VDA/Logs/vda.log"
 ```
+
 ##### Test Citrix Cloud connectivity:
-    
-    
-```
+
+```bash
 ansible mac_vms -i inventory.ini \
   -m shell \
   -a "curl -v https://[customer_ID].xendesktop.net 2>&1 | grep Connected"
 ```
+
 **Re-registration scenarios:**
 
 VMs may need to re-register if:

--- a/remote-desktop-vdi/orka-for-vdi-deployment/citrix-daas-configuration.mdx
+++ b/remote-desktop-vdi/orka-for-vdi-deployment/citrix-daas-configuration.mdx
@@ -555,15 +555,15 @@ ansible-playbook -i inventory.ini create_orka_vm.yml \
 
 Key parameters passed during VDA installation:
 
-  * `--enrollment-token` \- Token from Citrix Cloud (stored in Ansible Vault)
+  * `--enrollment-token` - Token from Citrix Cloud (stored in Ansible Vault)
 
-  * `--customer-id` \- Your Citrix Cloud customer ID
+  * `--customer-id` - Your Citrix Cloud customer ID
 
-  * `--cloud-connector` \- Citrix Cloud DaaS endpoint
+  * `--cloud-connector` - Citrix Cloud DaaS endpoint
 
-  * `--enable-rendezvous` \- Enable for non-domain-joined VMs
+  * `--enable-rendezvous` - Enable for non-domain-joined VMs
 
-  * `--delivery-controller` \- For on-premises CVAD (FQDN of controllers)
+  * `--delivery-controller` - For on-premises CVAD (FQDN of controllers)
 
 
 
@@ -666,7 +666,7 @@ Look for successful registration messages:
 
 
 
-###  **Common registration issues**
+### Common registration issues
 
 **Enrollment token problems:**
 

--- a/remote-desktop-vdi/orka-for-vdi-deployment/image-management.mdx
+++ b/remote-desktop-vdi/orka-for-vdi-deployment/image-management.mdx
@@ -74,29 +74,18 @@ Note: `pull_image.yml` automatically caches the image on all hosts in the invent
 
   8. Define your image retention policy by addressing the following questions:
 
-```
- 1. How long will you keep old image versions?
+     1. How long will you keep old image versions?
+     2. Which images will you always want to retain for rollback purposes?
+     3. When will you delete older image versions to free space if needed?
+     4. Will you store major image versions indefinitely? (Strongly recommended for auditing/compliance.)
+     5. When will you delete images tagged as dev/staging?
 
- 2. Which images will you always want to retain for rollback purposes?
+  9. Test before promoting images to production.
 
- 3. When will you delete older image versions to free space if needed?
+  10. Communicate image updates:
 
- 4. Will you store major image versions indefinitely? (This is strongly recommended for auditing/compliance)
-
- 5. When will you delete images tagged as dev/staging?
-```
-  9. Test before promoting images to production
-
-  10. Communicate image updates
-
-```
- 1. Notify all impacted stakeholders about updates to VM images
-
- 2. Announce new versions as needed in team channels
-
- 3. Document breaking changes
-
- 4. Schedule production deployments to take place during maintenance windows
-
- 5. Before updating an image, provide stakeholders with a rollback plan
-```
+      1. Notify all impacted stakeholders about updates to VM images.
+      2. Announce new versions as needed in team channels.
+      3. Document breaking changes.
+      4. Schedule production deployments to take place during maintenance windows.
+      5. Before updating an image, provide stakeholders with a rollback plan.

--- a/remote-desktop-vdi/orka-for-vdi-deployment/troubleshooting-common-issues.mdx
+++ b/remote-desktop-vdi/orka-for-vdi-deployment/troubleshooting-common-issues.mdx
@@ -62,7 +62,7 @@ zendesk_id: 44333132574107
 
 
 
-#####  **Issue:** Session fails to launch or times out
+### Issue: Session fails to launch or times out
 
 **Symptoms:**
 
@@ -98,13 +98,12 @@ zendesk_id: 44333132574107
 ```
   * Verify HDX ports are open
 
-```
-* Client → VM: TCP 1494, TCP 2598, UDP 1494, UDP 2598
+  * Client → VM: TCP 1494, TCP 2598, UDP 1494, UDP 2598
+  * Test with:
 
-* Test with 
-      
-      nc -zv <vm-ip> 1494
-```
+    ```
+    nc -zv <vm-ip> 1494
+    ```
   * Check client side for issues
 
 ```
@@ -131,7 +130,7 @@ zendesk_id: 44333132574107
 
 
 
-#####  **Issue:** Poor session performance or lag
+### Issue: Poor session performance or lag
 
 **Symptoms:**
 
@@ -162,15 +161,15 @@ zendesk_id: 44333132574107
 
 * Compare allocation to baseline requirements to ensure minimums are met
 ```
-  * Check network latency with 
-        
-```
+  * Check network latency with:
+
+    ```
     ping <vm-ip>
+    ```
 
-* Test bandwidth availability
+  * Test bandwidth availability
 
-* Check for packet loss
-```
+  * Check for packet loss
   * Review HDX policies
 
 ```
@@ -204,7 +203,7 @@ zendesk_id: 44333132574107
 
 
 
-#####  **Issue:** Clipboard or file transfer not working
+### Issue: Clipboard or file transfer not working
 
 **Symptoms:**
 
@@ -260,7 +259,7 @@ zendesk_id: 44333132574107
 
 
 
-#####  **Issue:** VM fails to deploy or gets stuck during deployment
+### Issue: VM fails to deploy or gets stuck during deployment
 
 **Symptoms:**
 
@@ -352,7 +351,7 @@ ansible-playbook -i inventory stop_orka_vm.yml \
 
 
 
-#####  **Issue:** Image operations fail
+### Issue: Image operations fail
 
 **Symptoms:**
 

--- a/remote-desktop-vdi/orka-for-vdi-deployment/validation-and-testing.mdx
+++ b/remote-desktop-vdi/orka-for-vdi-deployment/validation-and-testing.mdx
@@ -97,16 +97,13 @@ This test validates the complete user journey from authentication to desktop usa
 **Expected result:** Desktop launches successfully within 15-30 seconds, macOS login screen or desktop appears  
 **Common issues:**
 
-```
- * Connection timeout
-```
-Check network connectivity from client to Citrix Cloud
+- **Connection timeout:** Check network connectivity from client to Citrix Cloud.
 
-Verify the Rendezvous connectivity from within a running VDA session by opening Terminal and running:
-           
-```
-       curl -v https://[customer_ID].xendesktop.net 2>&1 | grep Connected
-```
+  Verify Rendezvous connectivity from within a running VDA session by opening Terminal and running:
+
+  ```bash
+  curl -v https://[customer_ID].xendesktop.net 2>&1 | grep Connected
+  ```
 2. Confirm firewall allows HDX ports (1494, 2598)
 
 3. If you see a black screen, the VDA service may not be running, restart the VDA service from within the VM:
@@ -419,18 +416,13 @@ Some metrics to consider measuring are:
 
   1. VM deployment time
 
-```
- 1. How long does it take from playbook execution to the time a VDA is registered?
+     - How long does it take from playbook execution to the time a VDA is registered?
+     - To establish a baseline, record the average, minimum, and maximum time across 10+ deployments and set an acceptable target (e.g. <5 minutes for cached images).
 
-    1. To establish a baseline, you may wish to record the average, minimum, and maximum time this takes across 10+ deployments and establish an acceptable target (e.g. &lt;5 minutes for cached images)
-```
   2. Session launch time
 
-```
- 1. How long does it take after clicking a desktop in Citrix Workspace to having a usable desktop?
-
-    1. To establish a baseline, you may want to test from multiple client locations such as office, remote, or mobile. An example target baseline metric may be &lt;15 seconds for Rendezvous, and &lt;10 seconds for a direct connection.
-```
+     - How long does it take after clicking a desktop in Citrix Workspace to having a usable desktop?
+     - To establish a baseline, test from multiple client locations such as office, remote, or mobile. An example target: <15 seconds for Rendezvous, <10 seconds for a direct connection.
   3. HDX session quality
 
 ```

--- a/remote-desktop-vdi/supporting-documentation/apple-business-manager-and-mobile-device-management-with-macstadium.mdx
+++ b/remote-desktop-vdi/supporting-documentation/apple-business-manager-and-mobile-device-management-with-macstadium.mdx
@@ -10,7 +10,7 @@ To support IT management activities for MacStadium customers, it is important to
 
 **ABM** is the Apple tool that enables an organization to register their Mac devices with their organization.
 
-**MDM/UEM tools****** enable enterprise configuration and management of Mac devices. Integration with ABM can often enable scalable workflows such as auto-enrollment of new and existing ABM devices to the MDM/UEM directory. Common examples of MDM/UEM tools are Jamf, Kandji, Workspace ONE, and Microsoft Intune.
+**MDM/UEM tools** enable enterprise configuration and management of Mac devices. Integration with ABM can often enable scalable workflows such as auto-enrollment of new and existing ABM devices to the MDM/UEM directory. Common examples of MDM/UEM tools are Jamf, Kandji, Workspace ONE, and Microsoft Intune.
 
 Apple Business Manager, when paired with a robust MDM/UEM platform, provides a scalable and secure foundation for deploying, configuring, and managing Mac devices across the enterprise. This seamless integration supports zero-touch provisioning, centralized policy enforcement, and secure access to organizational resources—empowering IT teams to efficiently manage Apple devices at scale.
 


### PR DESCRIPTION
## Summary

Heavier structural fixes in the Citrix VDI section — code blocks that were wrapping prose bullets and sub-steps instead of actual code.

- **citrix-daas-configuration**: 15 locations where ```` ``` ```` fenced blocks were wrapping Markdown bullet/numbered sub-lists have been converted to proper indented markdown lists. Actual commands (ansible, bash) now have correct language hints (`bash`, `yaml`). Extra leading spaces stripped from code block content throughout.
- **validation-and-testing**: Code block wrapping a "Connection timeout" bullet point converted to plain list item; HTML entity `&lt;` replaced with `<`; nested numbered sub-lists pulled out of code blocks.
- **image-management**: Image retention policy checklist and communication checklist flattened from misused code blocks into proper numbered sublists.

## Test plan

- [x] Mintlify preview renders numbered lists with sub-bullets correctly (no code font on prose content)
- [x] Code blocks for ansible commands display with proper syntax highlighting
- [x] No `&lt;` visible in rendered output (should show `<`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)