### PR TITLE
fix: accuracy batch 1 — callouts, copy-paste bugs, migration artifacts (19 files)

### DIFF
--- a/iaas/aws/aws-troubleshooting.mdx
+++ b/iaas/aws/aws-troubleshooting.mdx
@@ -56,13 +56,11 @@ For more information about route tables in Amazon, see [Amazon VPC Documentation
   2. In the top right corner of the screen, make sure that you're working in the correct region.
   3. In the VPC service sidebar, locate the Virtual Private Cloud menu and select Route Tables.  
 ![117e2d9-select-route-tables.png](/images/attachments/28312040787995.png)
-  4. In the list of routing tables, select the main table.  
+  4. In the list of routing tables, select the main table.
 
-```
- * At the bottom of the screen, select Route Propagation and make sure that the propagation is enabled. If your virtual private gateway is not listed, make sure that it's attached to the VPC.
- * If propagation is disabled, click Edit route propagation.
- * Select the Propagate checkbox and click Save.  
-```
+     * At the bottom of the screen, select **Route Propagation** and make sure that the propagation is enabled. If your virtual private gateway is not listed, make sure that it's attached to the VPC.
+     * If propagation is disabled, click **Edit route propagation**.
+     * Select the **Propagate** checkbox and click **Save**.
 ![e025068-route-propagation.png](/images/attachments/28312040790811.png)
 
 

--- a/iaas/aws/aws-vpn-config-for-cisco-asaasav.mdx
+++ b/iaas/aws/aws-vpn-config-for-cisco-asaasav.mdx
@@ -97,8 +97,7 @@ If you selected **ASA 9.7 + VTI** (route-based VPN), you need to enable the TCP 
   
 **Table 2: TCP State Bypass parameters**
 
-Place  
-holder | Description | More information | Example  
+Placeholder | Description | More information | Example  
 ---|---|---|---  
 `<acl-state-bypass>` | A unique name for the access control list that permits the creation of the tunnel and the traffic over it. | [Cisco Documentation: Access Control Lists](https://www.cisco.com/c/en/us/support/docs/security/ios-firewall/23602-confaccesslists.html) | `acl-state-bypass`  
 `<cm-state-bypass>` | A unique name for the class map that identifies the traffic for which to disable stateful firewall inspection. | [Cisco Documentation: TCP State Bypass](https://www.cisco.com/c/en/us/td/docs/security/asa/asa-cli-reference/A-H/asa-command-ref-A-H.html) | `cm-state-bypass`  

--- a/iaas/aws/verify-aws.mdx
+++ b/iaas/aws/verify-aws.mdx
@@ -10,10 +10,10 @@ Verify that there is an ISAKMP security association between the peers.
      * For more information about how to connect to the VPN, see [Connecting to Your Cloud via VPN](/remote-desktop-vdi/cloud-access-legacy/connect-to-your-cloud-via-vpn).
   2. Run Cisco ASDM-IDM and log in. 
      * For more information about how to log in to your firewall, see [Logging into Cisco Firewall](/iaas/cisco-firewalls/logging-into-cisco-firewall).
-  3. In the Cisco ASDM-IDM application toolbar, select **Tools > Command Line Interface  
-**![97da5cd-cisco-asdm-tools-menu.png](/images/attachments/28298213713435.png)
-  4. Select Single Line, enter the following command, and click Send.**  
-**
+  3. In the Cisco ASDM-IDM application toolbar, select **Tools > Command Line Interface**.
+![97da5cd-cisco-asdm-tools-menu.png](/images/attachments/28298213713435.png)
+  4. Select Single Line, enter the following command, and click **Send**.
+
 
 
     

--- a/iaas/cisco-firewalls/network-firewalls-for-ci-build-node-ansible.mdx
+++ b/iaas/cisco-firewalls/network-firewalls-for-ci-build-node-ansible.mdx
@@ -24,7 +24,9 @@ Ansible is a configuration management tool that is used to automate the setup of
 
 MacStadium provides an [Ansible playbook](https://docs.ansible.com/ansible/latest/user_guide/playbooks_intro.html) that takes care of the installation and setup of the tools need for a CI Build Node. The playbook is open-source and can be found [here](https://github.com/macstadium/ansible-playbook-osx-ci-setup).
 
-**Note** : The playbook works for OSX High Sierra and Mojave. It is capable of installing Xcode 8 and above. If you are using an older OSX version or require an older Xcode version, refer to our manual installation guide.
+<Note>
+The playbook works for OSX High Sierra and Mojave. It is capable of installing Xcode 8 and above. If you are using an older OSX version or require an older Xcode version, refer to our manual installation guide.
+</Note>
 
 The playbook is intended to be executed on the machine to set up as a CI Build Node. To execute the playbook remotely, to configure another [Ansible inventory](https://docs.ansible.com/ansible/2.4/intro_inventory.html).
 
@@ -62,8 +64,8 @@ git clone https://github.com/macstadium/ansible-playbook-osx-ci-setup.git
 ```
 This playbook consists of two roles:
 
-  * [OSX-CI](https://github.com/macstadium/ansible-role-osx-ci) \- Installs all common tooling and creates a user capable of running build jobs
-  * [Xcode](https://github.com/macstadium/ansible-role-xcode) \- Installs and configures Xcode
+  * [OSX-CI](https://github.com/macstadium/ansible-role-osx-ci) - Installs all common tooling and creates a user capable of running build jobs
+  * [Xcode](https://github.com/macstadium/ansible-role-xcode) - Installs and configures Xcode
 
 
 
@@ -78,7 +80,9 @@ ansible-galaxy install -r requirements.yml
 
 The [OSX-CI](https://github.com/macstadium/ansible-role-osx-ci) requires a path to a public ssh key on the target machine. The role adds the key to the `authorized_keys` file of the created user to enable remote login via ssh with a private key.
 
-**NOTE** : To use the target machine as a Jenkins agent you will need a key pair generated using the `RSA` algorithm.
+<Note>
+To use the target machine as a Jenkins agent you will need a key pair generated using the `RSA` algorithm.
+</Note>
 
 If you do not have a ssh key pair you can create one by executing on the target machine:
     
@@ -86,7 +90,9 @@ If you do not have a ssh key pair you can create one by executing on the target 
 ```
 ssh-keygen -m PEM -t rsa -C "build machine key" -f "buildMachine_rsa"
 ```
-**NOTE** : For increased security, it is recommended to associate a passphrase to the private key.
+<Note>
+For increased security, it is recommended to associate a passphrase to the private key.
+</Note>
 
 The command creates two files:
 
@@ -123,7 +129,7 @@ It is highly recommended not to pass the passwords in plain text.
 
 To encrypt use [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/playbooks_vault.html).
 
-Add the variable to [group_vars/all.yml](https://docs.macstadium.com/docs/group_vars/all.yml) and execute the following command:
+Add the variable to `group_vars/all.yml` and execute the following command:
     
     
 ```
@@ -139,6 +145,6 @@ To execute the Ansible playbook you can use the following command by replacing t
 ```
 ansible-playbook site.yml -i inventory -e ansible_user={AdminUser} -e xcode_xip_location={XcodeLocation} -e xcode_major_version={XcodeMajorVersion} -e ci_user_public_key_location={PublicSshKeyLocation} --ask-vault-pass
 ```
-You will be prompted for the vault password that you used to encrypt the [group_vars/all.yml](https://docs.macstadium.com/docs/group_vars/all.yml) file in the previous step.
+You will be prompted for the vault password that you used to encrypt the `group_vars/all.yml` file in the previous step.
 
 Once the execution is completed, you will have a fully-setup machine that you can use for OSX/iOS builds and for a Jenkins agent.

--- a/iaas/cisco-firewalls/network-firewalls-for-ci-build-node-homebrew.mdx
+++ b/iaas/cisco-firewalls/network-firewalls-for-ci-build-node-homebrew.mdx
@@ -16,7 +16,9 @@ Minimum requirements:
 
 
 
-**NOTE:** it is a good practice to have a bot user whose only responsibility is to build your OSX/iOS projects. This means such a user with the correct permissions should be created, so the user can build OSX/iOS projects.
+<Note>
+It is a good practice to have a bot user whose only responsibility is to build your OSX/iOS projects. This means such a user with the correct permissions should be created, so the user can build OSX/iOS projects.
+</Note>
 
 Do this via VNC or via the Web Console, or to enable Remote Login in the macOS settings, set SSH in.
 
@@ -72,12 +74,14 @@ To install the latest LTS run:
     
     
 ```
-brew install [node@10](mailto:node@10)  
+brew install node@10
 brew link node@10 --force
 ```
 This installs Node.js 10 LTS and links it to `/usr/local/bin` so it is available in `PATH`.
 
-**NOTE** : Consider using [nvm](https://github.com/creationix/nvm) to manage different Node.js versions. To install nvm run:
+<Note>
+Consider using [nvm](https://github.com/creationix/nvm) to manage different Node.js versions. To install nvm run:
+</Note>
     
     
 ```
@@ -208,7 +212,7 @@ To copy the private key to a secure machine that uses `scp`. This command execut
     
     
 ```
-scp /path-to-buildMachine_rsa/ [username@host:/path-to-location-on-secure-machine](mailto:username@host:/path-to-location-on-secure-machine)
+scp /path-to-buildMachine_rsa/ username@host:/path-to-location-on-secure-machine
 ```
 To create a `authorized_keys` file. It lists all keys that can be used to log remotely with a given user:
     

--- a/iaas/storage/restorable-snapshots.mdx
+++ b/iaas/storage/restorable-snapshots.mdx
@@ -12,16 +12,8 @@ Snapshots are particularly useful in the event of a misconfigured environment, a
 
 There are two types of snapshots:
 
-  * **Cloud Snapshot**
-
-```
-* A snapshot of an entire Private Cloud instance.
-```
-  * **VM Snapshot**
-
-```
-* A snapshot of an individual Virtual Machine.
-```
+  * **Cloud Snapshot** — a snapshot of an entire Private Cloud instance.
+  * **VM Snapshot** — a snapshot of an individual Virtual Machine.
 ### Snapshot Profiles
 
 Snapshots are created by using __snapshot profiles__. Once a snapshot profile is set up, it can be set to automatically snapshot machines on a regular basis according to stored schedules. The retention period, frequency, and machines snapshotted are all configurable. A snapshot profile can be assigned to an entire Private Cloud, an individual VM, or a NAS volume.
@@ -32,42 +24,29 @@ Private Cloud includes multiple default snapshot profiles that can be used out o
 
 Default profiles are readily available and can be modified if needed. The following are default snapshot profiles:
 
-  * **SOX****(Sarbanes-Oxley)**
+  * **SOX (Sarbanes-Oxley)**
 
-```
-* Yearly snapshots retained for 7 years
+     * Yearly snapshots retained for 7 years
+     * Monthly snapshots retained for 1 year
+     * Weekly snapshots retained for 31 days
+     * Daily snapshots retained for 7 days
 
-* Monthly snapshots retained for 1 year
-
-* Weekly snapshots retained for 31 days
-
-* Daily snapshots retained for 7 days
-```
   * **HIPAA (Health Insurance Portability & Accountability Act)**
 
-```
-* Yearly snapshots retained indefinitely (no expiration)
+     * Yearly snapshots retained indefinitely (no expiration)
+     * Monthly snapshots retained for 1 year
+     * Weekly snapshots retained for 31 days
+     * Daily snapshots retained for 7 days
 
-* Monthly snapshots retained for 1 year
+  * **NAS Volume Syncs**
 
-* Weekly snapshots retained for 31 days
+     * Daily (at 6pm) snapshots retained for 3 days
 
-* Daily snapshots retained for 7 days
-```
-  * **NAS****Volume Syncs**
+  * **\*Cloud Snapshots (Suggested default profile for entire-system snapshots)**
 
-```
-* Daily (at 6pm) snapshots retained for 3 days
-```
-  * ***Cloud Snapshots (Suggested default profile for entire-system snapshots)**
-
-```
-* Hourly for 3 hours
-
-* Daily (at midnight) snapshots retained for 3 days
-
-* Daily (at noon) snapshots retained for 1 day
-```
+     * Hourly for 3 hours
+     * Daily (at midnight) snapshots retained for 3 days
+     * Daily (at noon) snapshots retained for 1 day
 Any of the default profiles can be modified to meet individual needs or requirements.
 
 ### Using a Default Snapshot Profile
@@ -91,7 +70,7 @@ Any of the default profiles can be modified to meet individual needs or requirem
 
 ![Screenshot 2024-11-13 at 2.26.41 PM.png](/images/attachments/43967884635675.png)
 
-  4. Double-click SOX row, and the **SOX****Snapshot Profile** opens.
+  4. Double-click SOX row, and the **SOX Snapshot Profile** opens.
 
 
 
@@ -107,7 +86,9 @@ The default SOX snapshot profile has 4 periods:
 
 
 
-**NOTE** : There is a **\+ Add Period** , which can be used to add more snapshots. For example, a user might want an hourly snapshot or a 6-hour snapshot. The retention time can also be set.
+<Note>
+There is a **+ Add Period** button, which can be used to add more snapshots. For example, a user might want an hourly snapshot or a 6-hour snapshot. The retention time can also be set.
+</Note>
 
   6. In this example, click the **\+ Add Period** to modify the existing default snapshot profile. The **Snapshot Profile Period** screen opens.
 
@@ -173,11 +154,9 @@ If a Cloud Level Snapshot is configured, individual VM snapshots may not be need
 
 ![Screenshot 2024-12-16 at 2.24.22 PM.png](/images/attachments/43967884637467.png)
 
-  4. Select desired  __**snapshot profile**__ from the dropdown list
+  4. Select desired **snapshot profile** from the dropdown list.
 
-```
- * The default Cloud Snapshots profile is recommended as a starting point for Cloud Snapshots.
-```
+     * The default Cloud Snapshots profile is recommended as a starting point for Cloud Snapshots.
   5. Click **Submit** at the bottom of the page.
 
 

--- a/orka/networking-with-orka-at-macstadium/2-aws-vpn-tunnel-configuration-file.mdx
+++ b/orka/networking-with-orka-at-macstadium/2-aws-vpn-tunnel-configuration-file.mdx
@@ -6,14 +6,16 @@ zendesk_id: 28401474359835
 
 Download the VPN configuration file from Amazon and fill it in with your Orka network configuration.
 
-> #### **You need:**
-> 
->   * The name `Outside` from your [IP Plan](/macstadium/macstadium-overview/ip-plan).
->   * The IP address for the `Private-1` network from your [IP Plan](/macstadium/macstadium-overview/ip-plan).
->   * The subnet mask for the `Private-1` network from your [IP Plan](/macstadium/macstadium-overview/ip-plan).
->   * The IPv4 address of your Amazon VPC.
->   * The subnet mask for your Amazon VPC converted from its CIDR notation (i.e. `255.255.0.0` instead of `/16`).
-> 
+<Note>
+**You need:**
+
+  * The name `Outside` from your [IP Plan](/macstadium/macstadium-overview/ip-plan).
+  * The IP address for the `Private-1` network from your [IP Plan](/macstadium/macstadium-overview/ip-plan).
+  * The subnet mask for the `Private-1` network from your [IP Plan](/macstadium/macstadium-overview/ip-plan).
+  * The IPv4 address of your Amazon VPC.
+  * The subnet mask for your Amazon VPC converted from its CIDR notation (i.e. `255.255.0.0` instead of `/16`).
+</Note>
+
 
 
 After you [have created your VPN tunnel in Amazon](/orka/networking-with-orka-at-macstadium/1-aws-side-of-the-vpn-tunnel), you need to configure your Cisco firewall to recognize the connection and let traffic into your Orka cluster.
@@ -47,9 +49,9 @@ Amazon provides a semi-prefilled configuration file with very detailed instructi
 
 ## Step 2: Fill in the configuration file
 
-> #### **CAUTION**
-> 
-> Unless you have extensive experience with AWS and ASAv configurations, follow the instructions in the configuration file to the letter. Otherwise, your site-to-site VPN might not work as expected.
+<Warning>
+Unless you have extensive experience with AWS and ASAv configurations, follow the instructions in the configuration file to the letter. Otherwise, your site-to-site VPN might not work as expected.
+</Warning>
 
   1. Open the configuration file in a text editor.
   2. Replace all placeholders with their respective values.
@@ -69,7 +71,7 @@ Placeholder | Value | Description | More information
   
   3. Uncomment the following lines. To uncomment, remove `! `at the start of the line. 
      * `access-list amzn-filter extended permit ip ...`
-     * `object`\- and `nat`-related configuration at the end of the config file.
+     * `object`- and `nat`-related configuration at the end of the config file.
   4. Keep the following line. This ensures the SLA monitor works as expected.
 
 

--- a/orka/networking-with-orka-at-macstadium/built-in-orka-domains.mdx
+++ b/orka/networking-with-orka-at-macstadium/built-in-orka-domains.mdx
@@ -73,21 +73,17 @@ For example: 10.221.188.241.
 
 Due to Node.js limitations, the Orka CLI cannot work with Orka domains. You need to use your Orka API endpoint (http://10.221.188.20 or http://10.221.188.100) with the Orka CLI, or switch to another Orka tool.
 
-### TIP
-
+<Tip>
 You can use your Orka API endpoint (http://10.221.188.20 or http://10.221.188.100) and your Orka domain (https://company.orka.app) interchangeably in your workflows.
+</Tip>
 
   1. If you don't know what your Orka domain is, contact the MacStadium team.
 
   2. Configure your Orka tools to target the Orka domain. Note that you need to use https with your Orka domain.
 
-```
- * For the Orka API, change your API requests to target https://<orka-domain>.
-
- * For the Orka Web UI, open https://<orka-domain> in your browser.
-
- * For CI/CD integrations, switch to https://<orka-domain> in the respective plugin configuration.
-```
+     * For the Orka API, change your API requests to target `https://<orka-domain>`.
+     * For the Orka Web UI, open `https://<orka-domain>` in your browser.
+     * For CI/CD integrations, switch to `https://<orka-domain>` in the respective plugin configuration.
 ## 3\. (Orka API-only) Download and trust the Orka domain certificate
 
 To be able to run API calls against your Orka domain, you need to download the certificate for the Orka domain locally and add it to your trusted certificates.

--- a/orka/networking-with-orka-at-macstadium/external-custom-domains.mdx
+++ b/orka/networking-with-orka-at-macstadium/external-custom-domains.mdx
@@ -188,6 +188,6 @@ Finally, you need to target your external custom domain with your Orka tools. No
 
 
 
-#### **TIP**
-
+<Tip>
 You can use your Orka API endpoint (http://10.221.188.20 or http://10.221.188.100) and your custom domain (https://company.com) interchangeably in your workflows.
+</Tip>

--- a/orka/orka-cluster-access/orka-cluster-manage-access-to-resources.mdx
+++ b/orka/orka-cluster-access/orka-cluster-manage-access-to-resources.mdx
@@ -164,10 +164,8 @@ curl -X 'POST' \
 -H 'accept: application/json' \  
 -H 'Authorization: <TOKEN>' \  
 -H 'Content-Type: application/json' \  
--d '{  
-"namespace": "<TARGET_NAMESPACE>"  
-}'  
-  
+-d '{
+"namespace": "<TARGET_NAMESPACE>"
 }'
 ```
 There must be no running VMs on the node.
@@ -176,12 +174,12 @@ There must be no running VMs on the node.
 
 If needed, you can revoke the access of a user or a service account to a namespace. You need to remove the respective subjects from the respective role binding.
 
-  1. To add one or more users, run the following command:
+  1. To remove one or more users, run the following command:
 
 #### **Orka CLI**
-         
+
 ```
-     orka3 rb remove-subject --user user@company.com [--namespace <TARGET_NAMESPACE>]  
+     orka3 rb remove-subject --user user@company.com [--namespace <TARGET_NAMESPACE>]
        
      OR  
        
@@ -201,15 +199,16 @@ If needed, you can revoke the access of a user or a service account to a namespa
      ]  
      }'
 ```
-  2. To add one or more service accounts, run the following command:  
+  2. To remove one or more service accounts, run the following command:
+
 **Orka CLI**
-         
+
 ```
-     orka3 rb add-subject --serviceaccount <SA_NAMESPACE>:<SA_NAME> [--namespace <TARGET_NAMESPACE>]  
-       
-     OR  
-       
-     orka3 rb add-subject --serviceaccount <SA_NAMESPACE_2>:<SA_NAME_1>,<SA_NAMESPACE_2>:<SA_NAME_2> [--namespace <TARGET_NAMESPACE>]
+     orka3 rb remove-subject --serviceaccount <SA_NAMESPACE>:<SA_NAME> [--namespace <TARGET_NAMESPACE>]
+
+     OR
+
+     orka3 rb remove-subject --serviceaccount <SA_NAMESPACE_2>:<SA_NAME_1>,<SA_NAMESPACE_2>:<SA_NAME_2> [--namespace <TARGET_NAMESPACE>]
 ```
 #### **Orka API**
          

--- a/orka/orka-devops-integrations/packer.mdx
+++ b/orka/orka-devops-integrations/packer.mdx
@@ -10,15 +10,15 @@ The **[Orka Packer Plugin](https://github.com/macstadium/packer-plugin-macstadiu
 
 Tired of manually configuring and building your Orka images? The Orka Packer plugin is a great tool to use for automating your image builds. Not only is it easy to use and a great addition to any CI/CD pipeline, it can be used with additional plugins, such as Jenkins.
 
-> #### **IMPORTANT**
-> 
-> Orka 3.1.x and above requires version [3.0.0+](https://github.com/macstadium/packer-plugin-macstadium-orka/releases/tag/v3.0.1) of the plugin.
+<Warning>
+Orka 3.1.x and above requires version [3.0.0+](https://github.com/macstadium/packer-plugin-macstadium-orka/releases/tag/v3.0.1) of the plugin.
+</Warning>
 
 ## Working with the Plugin
 
-> #### **IMPORTANT**
-> 
-> Make sure that your local environment is connected to your Orka environment through VPN. You can use a [VPN client](/orka/networking-with-orka-at-macstadium/vpn-connection) to establish temporary connectivity, or you can create a [site-to-site VPN tunnel](/orka/networking-with-orka-at-macstadium/aws-orka-connections) to keep the connection alive at all times.
+<Warning>
+Make sure that your local environment is connected to your Orka environment through VPN. You can use a [VPN client](/orka/networking-with-orka-at-macstadium/vpn-connection) to establish temporary connectivity, or you can create a [site-to-site VPN tunnel](/orka/networking-with-orka-at-macstadium/aws-orka-connections) to keep the connection alive at all times.
+</Warning>
 
 For latest information on installing the plugin, please visit **[Orka Packer Plugin Installation](https://github.com/macstadium/packer-plugin-macstadium-orka/blob/main/README.md)**
 
@@ -26,9 +26,8 @@ For latest information on using the plugin, please visit **[Orka Packer Plugin U
 
 For latest information on configuring the plugin, please visit **[Orka Packer Plugin Configuration](https://github.com/macstadium/packer-plugin-macstadium-orka/blob/main/docs/builders/config.mdx)**
 
-> #### **CONTRIBUTING**
-> 
-> The Orka Packer Plugin is open-sourced under the GNU GPL v3 license.
-> 
-> To raise an issue with the plugin feel free to describe it by [opening a new issue in the Github repository](https://github.com/macstadium/packer-plugin-macstadium-orka/issues/new).  
-> To contribute to the source code by fixing a bug or adding a feature, review the [CONTRIBUTING guidelines](https://github.com/macstadium/packer-plugin-macstadium-orka#contributing).
+<Note>
+**Contributing:** The Orka Packer Plugin is open-sourced under the GNU GPL v3 license.
+
+To raise an issue with the plugin feel free to describe it by [opening a new issue in the Github repository](https://github.com/macstadium/packer-plugin-macstadium-orka/issues/new). To contribute to the source code by fixing a bug or adding a feature, review the [CONTRIBUTING guidelines](https://github.com/macstadium/packer-plugin-macstadium-orka#contributing).
+</Note>

--- a/orka/orka-engine/orka-engine-30.mdx
+++ b/orka/orka-engine/orka-engine-30.mdx
@@ -84,7 +84,7 @@ The following commands will quickly introduce basic features of the Orka Engine 
   * Listing images available on disk with `orka-engine image list`
   * Stop a VM with **ctrl-c** in terminal window bound to running VM or by closing the Dock item
   * Run a base template VM image hosted from MacStadium using `orka-engine vm run`
-    * orka-engine vm run latest-sonoma --image [http://ghcr.io/macstadium/orka-images/sonoma:latest](http://ghcr.io/macstadium/orka-images/sonoma:latest)
+    * `orka-engine vm run latest-sonoma --image ghcr.io/macstadium/orka-images/sonoma:latest`
   * Pulling remote images locally using `orka-engine image pull`
   * Starting a VM in the stopped state with `orka-engine vm start`
   * Pushing a configured CI/CD customized VM to a OCI container registry `orka-engine image push`
@@ -145,7 +145,9 @@ The ``--disable-graphical-console`` flag:
 
 
 
-**Note:** Without the graphical console, you must use SSH or other non-GUI methods to interact with the VM.
+<Note>
+Without the graphical console, you must use SSH or other non-GUI methods to interact with the VM.
+</Note>
     
     
 ```
@@ -154,9 +156,9 @@ orka-engine vm run sonoma-base \
   --disable-graphical-console \
   sonoma-fix
 ```
-Listing Current Running VMs
+## Listing Current Running VMs
 
-Orka engine can list the name and resource consumption of VMs are currently running or stopped on a local host.
+Orka engine can list the name and resource consumption of VMs that are currently running or stopped on a local host.
 
 ![Terminal output of orka-engine vm list showing a VM named latest-ipsw with 2 CPUs, 4096M memory, in running state](/images/attachments/39594527745947.png)
 
@@ -168,7 +170,7 @@ For example,`orka-engine vm save latest-ipsw sonoma146-vanilla` saves the VM cal
 
 ![Terminal confirmation: The image 'sonoma146-vanilla' for VM 'latest-ipsw' has been successfully saved](/images/attachments/39594591426971.png)
 
-Listing Images Available on Disk
+## Listing Images Available on Disk
 
 Orka Engine lists the images that are available on the local host. These images are used for starting a new VM immediately.
 
@@ -199,7 +201,12 @@ Starting VM sonoma-latest with MAC address f6:59:c1:15:5e:cb
 
 It is now possible to start a second terminal and run `orka-engine vm list`, and the following output appears, (which indicates that the previously running `latest-ipsw` VM has been stopped), and the recent `sonoma-latest` is now running. 
 
-`NAME CPU MEMORY STATE latest-ipsw 2 8192M running sonoma146-vanilla 2 4096M stopped sonoma-latest 2 4096M stopped`
+```
+NAME              CPU  MEMORY  STATE
+latest-ipsw       2    8192M   running
+sonoma146-vanilla 2    4096M   stopped
+sonoma-latest     2    4096M   stopped
+```
 
 Once VMs are in a stopped state, they can either be:
 
@@ -220,7 +227,7 @@ If the VM `latest-ipsw` is stopped in the above example, then it can be started 
 
 ## Deleting a VM
 
-If the VM `latest-ipsw` is stopped in the above example, then it can be deleted with the `orka-engine vm delete <vm--name>` command. 
+If the VM `latest-ipsw` is stopped in the above example, then it can be deleted with the `orka-engine vm delete <vm-name>` command. 
 
 ## Pulling Remote Images Locally
 

--- a/orka/orka-overview/orka-overview.mdx
+++ b/orka/orka-overview/orka-overview.mdx
@@ -50,7 +50,7 @@ This document will focus on using k8s as the control plane for Orka. For details
 ## Key Concepts
 
   * The [Orka CLI](/orka/orka-overview/tools-integrations) (`orka3`) is the primary interface to working with Orka when the control plane is a k8s environment. It is perfect for both manual use and automation.
-  * To build an automated CI/CD system, look into the available [Orka integrations](/orka/orka-overview/tools-integrations) \- from Jenkins to GitHub Actions. The Orka team continuously adds to the list of supported solutions.
+  * To build an automated CI/CD system, look into the available [Orka integrations](/orka/orka-overview/tools-integrations) - from Jenkins to GitHub Actions. The Orka team continuously adds to the list of supported solutions.
   * The [Orka Web UI](/orka/quick-start-guides/web-ui-quick-start) provides a quick and user-friendly way to manage an Orka. Currently, the Web UI offers limited functionality compared to the Orka3 CLI and the Orka3 API.
 
 

--- a/orka/orka-resources/apple-silicon-based-support.mdx
+++ b/orka/orka-resources/apple-silicon-based-support.mdx
@@ -20,9 +20,9 @@ VMs deployed on Apple silicon-based nodes use Apple Silicon images. A VM is depl
 
 When a VM is deployed on an Apple silicon-based node and this is the first time the image is used on the node, the deployment takes longer - about 4 minutes. Further deployments of VMs using the same image on the same node happen almost immediately and take about 5 seconds.
 
-#### **TIP**
-
+<Tip>
 To keep deployment times fast, you might want to make sure you deploy a VM on all nodes every time you create a new image. Keep in mind though, that images are cached on the nodes. If you try to deploy a VM from an image that is not cached and there is not enough space on the node, the oldest cached image(s) will be deleted to free space for the new one.
+</Tip>
 
 Below is a full list of features included in the Apple silicon-based support:
 
@@ -75,13 +75,13 @@ Orka 2.0:
 
 #### **GPU Passthrough and IO Boost**
 
-With VMs based on Apple Silicon images, GPU Passthrough comes out of the box. Therefore, the corresponding option --gpuis not applicable to them and will be ignored.
+With VMs based on Apple Silicon images, GPU Passthrough comes out of the box. Therefore, the corresponding option `--gpu` is not applicable to them and will be ignored.
 
 ## Limitations
 
-**IMPORTANT**
-
+<Warning>
 You can deploy up to 2 VMs per Apple silicon-based node.
+</Warning>
 
   1. The Apple silicon-based Support includes all the features needed to run your CI/CD workflows on Apple silicon-based nodes. Below is a full list of the ones that are still not there and will be considered in future versions of Orka:
 

--- a/orka/orka-resources/cluster-configurations.mdx
+++ b/orka/orka-resources/cluster-configurations.mdx
@@ -20,9 +20,9 @@ You can also control the VM scheduling algorithm when creating a VM configuratio
 
 Introduced with Orka 1.5.0 for MacPro hosts and with Orka 1.7.0 for Mac Mini hosts, GPU Passthrough allows you to use the GPU available on a node from within a VM deployed on that node. It is disabled by default and can be enabled in the cluster either at the time of cluster provisioning or during an API update.
 
-#### **Intel Only**
-
-GPU passthrough is available for Mac Intel nodes only. This configuration does not apply to Apple silicon nodes.
+<Note>
+**Intel only:** GPU passthrough is available for Mac Intel nodes only. This configuration does not apply to Apple silicon nodes.
+</Note>
 
 [Read more about GPU Passthrough, how to enable it and how to use it.](/orka/orka-configuration/performance-gpu-passthrough)
 

--- a/orka/orka-resources/consuming-metrics-from-prometheus.mdx
+++ b/orka/orka-resources/consuming-metrics-from-prometheus.mdx
@@ -14,7 +14,7 @@ If your organization is already using Prometheus and you wish to collect additio
 
 ### Orka Server and Operator Metrics
 
-#### **A Note About the Orka Server**
+#### A Note About the Orka Server
 
 Starting with Orka 3.0, the API server is no longer primarily responsible for managing Orka VMs. Instead, the operator is primarily responsible for managing the lifecycle of Orka VMs and other resources. Clients such as the orka3 CLI speak directly to the Kubernetes API instead of the Orka API.
 
@@ -35,9 +35,9 @@ curl -I 10.221.188.20:8080/metrics
 ```
 You should receive a response of 200 OK if all is well.
 
-#### **TIP**
-
-To view descriptions and additional information on the available Orka server metrics, try curl 10.221.188.20/metrics. For Orka operator metrics, try curl 10.221.188.20:8080/metrics
+<Tip>
+To view descriptions and additional information on the available Orka server metrics, try `curl 10.221.188.20/metrics`. For Orka operator metrics, try `curl 10.221.188.20:8080/metrics`.
+</Tip>
 
 In order to scrape the Orka server and operator metrics, add jobs to your Prometheus configuration:
 
@@ -80,9 +80,9 @@ curl -I http://10.221.188.31:9100/metrics
 ```
 If the node exporter is running and reachable from outside the cluster, you should receive a response of 200 OK.
 
-#### **Outside Access**
-
-If your Prometheus instance is hosted outside of the cluster, make sure that TCP traffic is permitted to port 9100 for all hosts on the Orka private network! For more information, see the section on IP plans.
+<Note>
+**Outside access:** If your Prometheus instance is hosted outside of the cluster, make sure that TCP traffic is permitted to port 9100 for all hosts on the Orka private network. For more information, see the section on IP plans.
+</Note>
 
 In order to scrape the node exporter data, add a job to your Prometheus configuration. For example:
 
@@ -106,6 +106,6 @@ group: 'x86'
 labels:  
 group: 'arm'
 ```
-#### **TIP**
-
+<Tip>
 As an alternative to the static config, you can use [file-based service discovery](https://prometheus.io/docs/guides/file-sd/) to scrape the targets.
+</Tip>

--- a/orka/orka-resources/image-caching.mdx
+++ b/orka/orka-resources/image-caching.mdx
@@ -39,7 +39,9 @@ The cluster knows which nodes have necessary images cached, greatly reducing ima
 
 
 
-Note: Orka Cluster 3.0 and later can deploy a VM from multiple image sources: a cloud image datastore (OCI registry service), Orka’s local cluster registry (Cluster NFS mount), and lastly cached images on a cluster node member. Now in Orka 3.2 release there are three distinct CLI commands to display each type of storage and the images available on that specific datastore.
+<Note>
+Orka Cluster 3.0 and later can deploy a VM from multiple image sources: a cloud image datastore (OCI registry service), Orka’s local cluster registry (Cluster NFS mount), and lastly cached images on a cluster node member. Now in Orka 3.2 release there are three distinct CLI commands to display each type of storage and the images available on that specific datastore.
+</Note>
 
 # Getting Started
 

--- a/orka/orka-resources/resiliency-high-availability-and-disaster-recovery.mdx
+++ b/orka/orka-resources/resiliency-high-availability-and-disaster-recovery.mdx
@@ -14,9 +14,9 @@ Orka provides orchestration and virtualization for virtualized runtime environme
 
 This document outlines the built-in Resiliency, High Availability (HA), and Disaster Recovery (DR) capabilities of Orka Cluster components when hosted on MacStadium. The document also outlines additional solutions, which can be implemented with added complexity and cost to achieve more advanced setups.
 
-> 🗒️**NOTE**
->
-> It is important to note that HA/DR setups can vary significantly in complexity and cost, based on individual needs.
+<Note>
+It is important to note that HA/DR setups can vary significantly in complexity and cost, based on individual needs.
+</Note>
 
 Orka Cluster provides substantial resiliency as part of its core offering, which is achieved by balancing effectiveness, sound expectations, and shared responsibilities between MacStadium and our customers.
 
@@ -113,9 +113,9 @@ In the event of a failure at one data center, the load balancer is reconfigured 
 
 Effective High Availability / Disaster Recovery is a shared responsibility between MacStadium and our customers.
 
-> 🗒️**NOTE**
->
-> Understanding these responsibilities is crucial for maintaining a robust HA/DR posture.
+<Note>
+Understanding these responsibilities is crucial for maintaining a robust HA/DR posture.
+</Note>
 
 ### MacStadium Responsibilities
 

--- a/remote-desktop-vdi/operational-guides/ansible-quick-reference.mdx
+++ b/remote-desktop-vdi/operational-guides/ansible-quick-reference.mdx
@@ -186,20 +186,17 @@ ansible-playbook -i inventory pull_image.yml \
 
 ### MacStadium Public Images
 
-  * **Sonoma** : [](http://ghcr.io/macstadium/orka-images/sonoma:latest)[GitHub](http://ghcr.io/macstadium/orka-images/sonoma:latest)
-
-  * **Ventura** : [](http://ghcr.io/macstadium/orka-images/ventura:latest)[GitHub](http://ghcr.io/macstadium/orka-images/ventura:latest)
-
-  * **Monterey** : [ghcr.io/macstadium/orka-images/monterey:latest](http://ghcr.io/macstadium/orka-images/monterey:latest "http://ghcr.io/macstadium/orka-images/monterey:latest")
+  * **Sonoma**: `ghcr.io/macstadium/orka-images/sonoma:latest`
+  * **Ventura**: `ghcr.io/macstadium/orka-images/ventura:latest`
+  * **Monterey**: `ghcr.io/macstadium/orka-images/monterey:latest`
 
 
 
 
 ### Private Registry Format
 
-  * **Full path** : [registry.example.com/organization/repository:tag](http://registry.example.com/organization/repository:tag "http://registry.example.com/organization/repository:tag")
-
-  * **With port** : [registry.example.com:5000/orka/image:v1.0](http://registry.example.com:5000/orka/image:v1.0 "http://registry.example.com:5000/orka/image:v1.0")
+  * **Full path**: `registry.example.com/organization/repository:tag`
+  * **With port**: `registry.example.com:5000/orka/image:v1.0`
 
 
 
@@ -356,19 +353,7 @@ ansible-playbook -i /inventory <playbook.yml> --step
 
   * **Support Portal** : [support@macstadium.com](mailto:support@macstadium.com)
 
-  * **CLI Reference** : 
-        
-```
-    orka-engine --help
-```
-  * **VM Commands** : 
-        
-```
-    orka-engine vm --help
-```
-  * **Image Commands** : 
-        
-```
-    orka-engine image --help
-```
+  * **CLI Reference**: `orka-engine --help`
+  * **VM Commands**: `orka-engine vm --help`
+  * **Image Commands**: `orka-engine image --help`
   * **Project README** : Check your repository's README.md for architecture details


### PR DESCRIPTION
## Summary

- **Callout conversions** (19 instances across 10 files): raw `NOTE`/`TIP`/`IMPORTANT`/`CAUTION` headings and `> 🗒️` blockquotes → proper Mintlify `<Note>`, `<Warning>`, `<Tip>` components
- **Content bug fix** in `orka-cluster-manage-access-to-resources`: the "Revoke access" section was a copy-paste of the "Grant access" section — "To add" text and `rb add-subject` CLI commands corrected to "To remove" / `rb remove-subject`; stray duplicate closing brace removed from API code block
- **Migration artifact cleanup** across 10 files: `\-` escaped hyphens, `mailto:` links wrapping OCI image names and shell arguments, broken table header split across lines, malformed bold tags spanning line breaks, Zendesk docs URLs replaced with inline code

## Files changed (19)

| File | Fix |
|------|-----|
| `orka/networking-with-orka-at-macstadium/2-aws-vpn-tunnel-configuration-file` | Blockquotes → `<Note>`/`<Warning>`; `object\-` → `object-` |
| `orka/orka-resources/apple-silicon-based-support` | TIP heading → `<Tip>`; IMPORTANT → `<Warning>`; `--gpuis` typo |
| `orka/networking-with-orka-at-macstadium/built-in-orka-domains` | TIP heading → `<Tip>`; code block bullets → list items |
| `orka/orka-resources/cluster-configurations` | Intel Only heading → `<Note>` |
| `orka/orka-resources/consuming-metrics-from-prometheus` | Bold heading → plain; 2× TIP → `<Tip>`; Outside Access → `<Note>` |
| `orka/networking-with-orka-at-macstadium/external-custom-domains` | TIP heading → `<Tip>` |
| `orka/orka-resources/image-caching` | Bare `Note:` text → `<Note>` |
| `iaas/cisco-firewalls/network-firewalls-for-ci-build-node-ansible` | 3× NOTE → `<Note>`; `\-` → `-`; Zendesk links → inline code |
| `iaas/cisco-firewalls/network-firewalls-for-ci-build-node-homebrew` | 2× NOTE → `<Note>`; `mailto:` links → plain text |
| `orka/orka-engine/orka-engine-30` | `<Note>` component; missing `##` headings; VM list → code block; `<vm--name>` typo; broken markdown link |
| `orka/orka-devops-integrations/packer` | 2× IMPORTANT blockquotes → `<Warning>`; CONTRIBUTING → `<Note>` |
| `orka/orka-resources/resiliency-high-availability-and-disaster-recovery` | 2× NOTE blockquotes → `<Note>` |
| `iaas/storage/restorable-snapshots` | NOTE → `<Note>`; extra `****` asterisks; code block bullets → list items |
| `orka/orka-cluster-access/orka-cluster-manage-access-to-resources` | **Bug fix:** Revoke section had copy-pasted "add" text and `rb add-subject` CLI commands |
| `orka/orka-overview/orka-overview` | `\-` → `-` |
| `iaas/aws/aws-troubleshooting` | Code block bullets → list items |
| `iaas/aws/aws-vpn-config-for-cisco-asaasav` | Broken table header `Place\nholder` → `Placeholder` |
| `iaas/aws/verify-aws` | Malformed bold tags across line breaks |
| `remote-desktop-vdi/operational-guides/ansible-quick-reference` | Broken double-link image names → inline code; CLI help commands → inline code |

## Test plan

- [x] Mintlify preview renders `<Note>`, `<Warning>`, `<Tip>` components correctly
- [x] Orka CLI revoke commands show `rb remove-subject` (not `rb add-subject`)
- [x] No broken links or malformed tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)