### PR TITLE
fix(docs.json): convert ga4 integration from string to object

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -29,7 +29,7 @@
     "telemetry": {
       "enabled": true
     },
-    "ga4": "G-LW571X03HJ"
+    "ga4": { "measurementId": "G-LW571X03HJ" }
   },
   "navigation": {
     "versions": [


### PR DESCRIPTION
## Summary

Mintlify's schema now requires `ga4` to be an object, not a string. This was causing `Mintlify Deployment` to fail on any PR branched from current `main`.

**Change:**
```json
// Before
"ga4": "G-LW571X03HJ"

// After
"ga4": { "measurementId": "G-LW571X03HJ" }
```

PRs #93 and #94 both have this fix applied to their branches already so their deployments should now pass. This PR fixes `main` so future branches don't inherit the broken format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)