### PR TITLE
Remove raise issue button, update support link

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -15,7 +15,7 @@
     "links": [
       {
         "name": "Support",
-        "url": "https://support.macstadium.com"
+        "url": "https://portal.macstadium.com/support-center/tickets"
       },
       {
         "name": "Portal",
@@ -29,7 +29,7 @@
   },
   "feedback": {
     "suggestEdit": true,
-    "raiseIssue": true
+    "raiseIssue": false
   },
   "integrations": {
     "telemetry": {


### PR DESCRIPTION
## Summary
- Disables the \"Raise Issue\" GitHub button on all docs pages — users were mistaking it for a support ticket form
- Updates the Support topbar link from the deprecated Zendesk URL to the portal ticket submission page (`portal.macstadium.com/support-center/tickets`)

## Test plan
- [x] Confirm \"Raise Issue\" button no longer appears on any docs page
- [x] Confirm Support topbar link goes to the correct portal tickets URL
- [x] Confirm \"Suggest Edit\" button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)