### PR TITLE
fix: wrap \<placeholder> patterns in backticks to fix MDX parse errors

### DIFF
--- a/iaas/aws/aws-troubleshooting.mdx
+++ b/iaas/aws/aws-troubleshooting.mdx
@@ -69,7 +69,7 @@ For more information about route tables in Amazon, see [Amazon VPC Documentation
 
 All checks in this section are performed against the site-to-site VPN configuration file downloaded from Amazon. For more information, see [AWS VPN Config for Cisco ASA/ASAv.](/iaas/aws/aws-vpn-config-for-cisco-asaasav)
 
-**Verify that you've replaced \<local_subnet> and \<local_subnet_mask> with the correct values for the internal, private network of your MacStadium private cloud.**
+**Verify that you've replaced `<local_subnet>` and `<local_subnet_mask>` with the correct values for the internal, private network of your MacStadium private cloud.**
 
 By default, this is the Private-1 network.
 

--- a/iaas/aws/site-to-site-vpn-configuration-with-aws.mdx
+++ b/iaas/aws/site-to-site-vpn-configuration-with-aws.mdx
@@ -288,7 +288,7 @@ By default, this is the Private-1 network. | [The IP Plan](/macstadium/macstadiu
      * To uncomment, remove ! at the start of the line.
      * Keep the following line to ensure the SLA monitor works as expected. 
        * `object network obj-SrcNet subnet 0.0.0.0 0.0.0.0`
-       * **WARNING** : Based on the network configuration and requirements, the line can be modified to map to the subnet and the subnet mask for the Private-1 network from your IP Plan. If this line is modified, then do not configure the \<sla_monitor_address> value.
+       * **WARNING** : Based on the network configuration and requirements, the line can be modified to map to the subnet and the subnet mask for the Private-1 network from your IP Plan. If this line is modified, then do not configure the `<sla_monitor_address>` value.
   6. On the following line, change 0.0.0.0 0.0.0.0 to a combination of the IP address and the subnet mask for your Amazon VPC. 
      * These values are in the AWS Management Console. Navigate to the VPC dashboard and select the VPC, and check the Description at the bottom of the screen.
      * Convert the subnet mask bit notation to the correct subnet mask (for example, the /16 notation converts to a 255.255.0.0 subnet mask).
@@ -351,14 +351,14 @@ screen. | 172.31.0.0
 
   2. Open the configuration file.
 
-  3. Replace the placeholders with their respective values. Currently, only the placeholder \<outside_interface> is available in the AWS script. Use Table 1: Configuration parameters for reference.
+  3. Replace the placeholders with their respective values. Currently, only the placeholder `<outside_interface>` is available in the AWS script. Use Table 1: Configuration parameters for reference.
 
   4. Change the name of the tunnel interfaces. Example:
 
 ```
  * interface tunnel 100 nameif aws-vpn-1 interface tunnel 200 nameif aws-vpn-2
 ```
-  5. Replace the network address and mask on the BGP configuration. Example: router bgp 65513 address-family ipv4 unicast network \<local_subnet> mask \<local_subnet_mask>
+  5. Replace the network address and mask on the BGP configuration. Example: router bgp 65513 address-family ipv4 unicast network `<local_subnet>` mask `<local_subnet_mask>`
 
   6. Replace the placeholders with their respective values.
 
@@ -384,8 +384,8 @@ TCP State Bypass | cm-state-bypass
 ```
 | A unique name for the access control list that permits the creation of the tunnel and the traffic over it. | Cisco Documentation:  
 TCP State Bypass | pm-state-bypass  
-     * Define the Access list with the source and destination networks: access-list \<acl-state-bypass> extended permit ip 
-       * \<local_subnet> \<local_subnet_mask> \<vpc_subnet> \<vpc_subnet_mask>
+     * Define the Access list with the source and destination networks: access-list `<acl-state-bypass>` extended permit ip 
+       * `<local_subnet>` `<local_subnet_mask>` `<vpc_subnet>` `<vpc_subnet_mask>`
 
 ```
  * Create the Class Map to identify the traffic for which you want to disable stateful Firewall inspection: 

--- a/iaas/azure/verify-azure.mdx
+++ b/iaas/azure/verify-azure.mdx
@@ -59,22 +59,22 @@ For more information about this verification command, see [Cisco Documentation: 
   1. Verify that you have created a virtual machine in MacStadium.
   2. Verify that you have created a virtual machine in Azure.
   3. In the terminal on your MacStadium VM, run the following command. 
-     * Replace \<user> with the username for your Azure VM.
-     * Replace \<azure-vm-ip> with the private IP of the Azure VM. 
+     * Replace `<user>` with the username for your Azure VM.
+     * Replace `<azure-vm-ip>` with the private IP of the Azure VM. 
            
 ```
        ssh <user>@<azure-vm-ip>
 ```
   4. When prompted, provide your password or key for the specified username on the specified Azure VM. 
-     * If the connection is successful, the prefix of the terminal becomes \<user>@\<azure-vm-ip>. This indicates that you have connected from MacStadium to Azure over the tunnel.
+     * If the connection is successful, the prefix of the terminal becomes `<user>`@`<azure-vm-ip>`. This indicates that you have connected from MacStadium to Azure over the tunnel.
   5. Run the following command. 
-     * Replace \<user> with the username for your MacStadium VM.
-     * Replace \<macstadium-vm-ip> with the private IP of the MacStadium VM. 
+     * Replace `<user>` with the username for your MacStadium VM.
+     * Replace `<macstadium-vm-ip>` with the private IP of the MacStadium VM. 
            
 ```
        ssh <user>@<macstadium-vm-ip>
 ```
-  6. When prompted, provide your password or key for the specified username on the specified MacStadium VM. If the connection is successful, the prefix of the terminal becomes \<user>@\<macstadium-vm-ip>. This indicates that you have connected from Azure to MacStadium over the tunnel.
+  6. When prompted, provide your password or key for the specified username on the specified MacStadium VM. If the connection is successful, the prefix of the terminal becomes `<user>`@`<macstadium-vm-ip>`. This indicates that you have connected from Azure to MacStadium over the tunnel.
 
 
 

--- a/iaas/cisco-firewalls/network-firewalls-cloud-connect-vpn.mdx
+++ b/iaas/cisco-firewalls/network-firewalls-cloud-connect-vpn.mdx
@@ -92,7 +92,7 @@ The DNS server address is the `.251` address for the `Private-1` network from th
 
 ### Use OpenConnect
 
-  1. From the command line, run the following command. Replace \<SERVER ADDRESS> with the server address from Step 1: VPN in the IP Plan.
+  1. From the command line, run the following command. Replace `<SERVER ADDRESS>` with the server address from Step 1: VPN in the IP Plan.
 
      ```
      sudo openconnect <SERVER ADDRESS> --protocol=anyconnect

--- a/iaas/google-cloud-platform/verify-gcp.mdx
+++ b/iaas/google-cloud-platform/verify-gcp.mdx
@@ -61,23 +61,23 @@ For more information about this verification command, see [Cisco Documentation: 
   2. Verify that you have created a virtual machine instance in GCP and that you have enabled user login on it. 
      * For more information about user login on GCP instances, see [Google Cloud Documentation: Setting up and configuring OS Login](https://cloud.google.com/compute/docs/instances/managing-instance-access).
   3. In the terminal on your MacStadium VM, run the following command. 
-     * Replace \<user> with the username for your GCP instance.
-     * Replace \<gcp-vm-ip> with the private IP of the GCP instance. 
+     * Replace `<user>` with the username for your GCP instance.
+     * Replace `<gcp-vm-ip>` with the private IP of the GCP instance. 
            
 ```
        ssh <user>@<gcp-vm-ip>
 ```
   4. When prompted, provide your password or key for the specified username on the specified GCP instance. 
-     * If the connection is successful, the prefix of the terminal becomes \<user>@\<gcp-vm-ip>. This indicates that you have connected from MacStadium to GCP over the tunnel.
+     * If the connection is successful, the prefix of the terminal becomes `<user>`@`<gcp-vm-ip>`. This indicates that you have connected from MacStadium to GCP over the tunnel.
   5. Run the following command. 
-     * Replace \<user> with the username for your MacStadium VM.
-     * Replace \<macstadium-vm-ip> with the private IP of the MacStadium VM. 
+     * Replace `<user>` with the username for your MacStadium VM.
+     * Replace `<macstadium-vm-ip>` with the private IP of the MacStadium VM. 
            
 ```
        ssh <user>@<macstadium-vm-ip>
 ```
   6. When prompted, provide your password or key for the specified username on the specified MacStadium VM. 
-     * If the connection is successful, the prefix of the terminal becomes \<user>@\<macstadium-vm-ip>. This indicates that you have connected from GCP to MacStadium over the tunnel.
+     * If the connection is successful, the prefix of the terminal becomes `<user>`@`<macstadium-vm-ip>`. This indicates that you have connected from GCP to MacStadium over the tunnel.
 
 
 

--- a/orka/kubernetes-native/k8s-native-persistent-volumes.mdx
+++ b/orka/kubernetes-native/k8s-native-persistent-volumes.mdx
@@ -82,7 +82,7 @@ spec:
 ```
 The values for metadata:name and metadata:namespace must match the values for claimRef:name and claimRef:namespace declared in the manifest of the persistent volume. Double-check with the MacStadium team for these values.
 
-  2. Apply the PVC. Replace pvc.yaml with the complete file path to your own PVC manifest. Replace \<NAMESPACE> with the namespace you created earlier. 
+  2. Apply the PVC. Replace pvc.yaml with the complete file path to your own PVC manifest. Replace `<NAMESPACE>` with the namespace you created earlier. 
          
 ```
      kubectl apply -f pvc.yaml --namespace=<NAMESPACE>
@@ -100,7 +100,7 @@ If the persistent volume claim works as expected, you will see a similar output:
 
 **Status Pending?**
 
-If the status is Pending instead of Bound, double-check your PVC manifest, fix any naming issues, remove the old pvc with kubectl delete pvc \<NAME>, and re-apply the fixed manifest. If the problem persists, contact the MacStadium team.
+If the status is Pending instead of Bound, double-check your PVC manifest, fix any naming issues, remove the old pvc with kubectl delete pvc `<NAME>`, and re-apply the fixed manifest. If the problem persists, contact the MacStadium team.
 
 ## Step 4: Deploy a pod that uses the persistent volume
 

--- a/orka/networking-with-orka-at-macstadium/external-custom-domains.mdx
+++ b/orka/networking-with-orka-at-macstadium/external-custom-domains.mdx
@@ -62,13 +62,13 @@ curl -X POST 'http://<orka-api-url>/resources/cert/set' \
 --form 'certPath=@<full-path-to-the-certificate>' \  
 --form 'keyPath=@<full-path-to-the-private-key>'
 ```
-Replace \<orka-api-ip> with 10.221.188.20 or 10.221.188.100.
+Replace `<orka-api-ip>` with 10.221.188.20 or 10.221.188.100.
 
-Replace \<token> with your Orka token.
+Replace `<token>` with your Orka token.
 
-Replace \<license-key> with your actual Orka license key.
+Replace `<license-key>` with your actual Orka license key.
 
-Replace \<full-path-to-the-certificate> and \<full-path-to-the-private-key> with the full paths to the certificate and the private key on your local machine.
+Replace `<full-path-to-the-certificate>` and `<full-path-to-the-private-key>` with the full paths to the certificate and the private key on your local machine.
 
 ## 3\. Map the domain to your cluster Ingress
 

--- a/orka/networking-with-orka-at-macstadium/vpn-connection.mdx
+++ b/orka/networking-with-orka-at-macstadium/vpn-connection.mdx
@@ -37,7 +37,7 @@ If you are a pre-dominantly CLI user, you might want to use [OpenConnect](https:
 
 ### Use OpenConnect
 
-  1. From your command line, run the following command. Replace \<SERVER ADDRESS> with the server address from Step 1: VPN in the IP Plan. 
+  1. From your command line, run the following command. Replace `<SERVER ADDRESS>` with the server address from Step 1: VPN in the IP Plan. 
          
 ```
      sudo openconnect <SERVER ADDRESS> --protocol=anyconnect  

--- a/orka/oci-images/oci-images-manage-registry-credentials.mdx
+++ b/orka/oci-images/oci-images-manage-registry-credentials.mdx
@@ -39,7 +39,7 @@ curl -X 'GET' \
 ```
 ## Add registry credentials
 
-Note that the \<SERVER_ADDRESS> for the registry must include the scheme, hostname, and (optionally) port. For example, https://ghcr.io or https://10.221.188.5:30080.
+Note that the `<SERVER_ADDRESS>` for the registry must include the scheme, hostname, and (optionally) port. For example, https://ghcr.io or https://10.221.188.5:30080.
 
 #### **Orka CLI**
     

--- a/orka/orka-cluster-access/orka-cluster-access-the-cluster.mdx
+++ b/orka/orka-cluster-access/orka-cluster-access-the-cluster.mdx
@@ -32,11 +32,11 @@ You can get your Orka API URL from your [IP Plan](/macstadium/macstadium-overvie
 
   * For clusters deployed before Orka 2.1, it's the .100 address for your Private-1 network (usually, 10.221.188.100), prefixed with http. For example: http://10.221.188.100.
   * For clusters deployed with Orka 2.1 or later, it's the .20 address for your Private-1 network (usually 10.221.188.20), prefixed with http. For example: http://10.221.188.20.
-  * You can also use https://\<orka-domain> and https://\<custom-domain>(if configured). To get the Orka domain for your Orka cluster, contact MacStadium. To use an external custom domain, see here.
+  * You can also use https://`<orka-domain>` and https://`<custom-domain>`(if configured). To get the Orka domain for your Orka cluster, contact MacStadium. To use an external custom domain, see here.
 
 
 
-**Note:** You can use http://\<orka-IP>, https://\<orka-domain>, and https://\<custom-domain> interchangeably in your workflows.
+**Note:** You can use http://`<orka-IP>`, https://`<orka-domain>`, and https://`<custom-domain>` interchangeably in your workflows.
 
 ## Log in to the Orka cluster
 
@@ -44,7 +44,7 @@ Orka customers log in to their cluster with their MacStadium Customer Portal cre
 
 ### Using the Orka3 CLI
 
-If this is the first time you are logging in after installing the Orka CLI, you need to add the \<ORKA_ENDPOINT> to your CLI configuration:
+If this is the first time you are logging in after installing the Orka CLI, you need to add the `<ORKA_ENDPOINT>` to your CLI configuration:
     
     
 ```
@@ -74,7 +74,7 @@ If you are using Orka Web UI, complete the following steps:
      orka3 serviceaccount token <SERVICE_ACCOUNT>
 ```
 
-  2. In the browser, navigate to your \<ORKA_ENDPOINT> and, when prompted, provide the token obtained in Step 1.
+  2. In the browser, navigate to your `<ORKA_ENDPOINT>` and, when prompted, provide the token obtained in Step 1.
 
 
 
@@ -104,11 +104,11 @@ If you are using the Orka API, complete the following steps:
      orka3 serviceaccount token <SERVICE_ACCOUNT>
 ```
 
-  2. In the browser, navigate to your \<ORKA_ENDPOINT>/api/v1/swagger and click Authorize.
+  2. In the browser, navigate to your `<ORKA_ENDPOINT>`/api/v1/swagger and click Authorize.
 
-  3. In the Value text box, type Bearer \<TOKEN> and click Authorize.
+  3. In the Value text box, type Bearer `<TOKEN>` and click Authorize.
 
-  4. Replace \<TOKEN> with the token obtained in Step 1.
+  4. Replace `<TOKEN>` with the token obtained in Step 1.
 
   5. Click Close
 

--- a/orka/orka-on-aws-and-on-prem/orka-on-prem-getting-started.mdx
+++ b/orka/orka-on-aws-and-on-prem/orka-on-prem-getting-started.mdx
@@ -287,7 +287,7 @@ To use the MacStadium provided functionality you need to:
   3. Run the container
          
 ```
-     docker run -it -v \<kube_config_location>:/root/.kube/config -v backup.yml:/ansible/group_vars/all/backup.yml 519920272850.dkr.ecr.us-east-1.amazonaws.com/orka-ansible-onprem:3.5.0 bash  
+     docker run -it -v `<kube_config_location>`:/root/.kube/config -v backup.yml:/ansible/group_vars/all/backup.yml 519920272850.dkr.ecr.us-east-1.amazonaws.com/orka-ansible-onprem:3.5.0 bash  
 ```
   4. Run the backup playbook inside the `/ansible` folder
          


### PR DESCRIPTION
## Summary

`\<placeholder>` patterns in prose MDX cause deployment failures — MDX tries to parse `<placeholder>` as a JSX opening tag and errors out. Backslash escaping doesn't prevent this. Wrapping in backtick inline code is the correct fix.

**11 files changed across `iaas/` and `orka/`:**
- `iaas/aws/aws-troubleshooting.mdx`
- `iaas/aws/site-to-site-vpn-configuration-with-aws.mdx`
- `iaas/azure/verify-azure.mdx`
- `iaas/cisco-firewalls/network-firewalls-cloud-connect-vpn.mdx`
- `iaas/google-cloud-platform/verify-gcp.mdx`
- `orka/kubernetes-native/k8s-native-persistent-volumes.mdx`
- `orka/networking-with-orka-at-macstadium/external-custom-domains.mdx`
- `orka/networking-with-orka-at-macstadium/vpn-connection.mdx`
- `orka/oci-images/oci-images-manage-registry-credentials.mdx`
- `orka/orka-cluster-access/orka-cluster-access-the-cluster.mdx`
- `orka/orka-on-aws-and-on-prem/orka-on-prem-getting-started.mdx`

## Test plan
- [x] Mintlify preview deploys without MDX parse errors
- [x] Placeholders render as inline code in the preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)