### PR TITLE
fix: remove raiseIssue key to hide Raise Issue button

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -28,8 +28,7 @@
     "repo": "macstadium-docs"
   },
   "feedback": {
-    "suggestEdit": true,
-    "raiseIssue": false
+    "suggestEdit": true
   },
   "integrations": {
     "telemetry": {


### PR DESCRIPTION
## Summary

Setting `raiseIssue: false` does not hide the button in Mintlify — the key needs to be absent entirely. Removes the key.

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)