### PR TITLE
docs: add Android Virtual Devices page and update VDI docs for vm_name API

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -295,6 +295,7 @@
               "remote-desktop-vdi/macstadium-vdi-deployment/citrix-daas-configuration",
               "remote-desktop-vdi/macstadium-vdi-deployment/image-management",
               "remote-desktop-vdi/macstadium-vdi-deployment/jamf-enrollment",
+              "remote-desktop-vdi/macstadium-vdi-deployment/android-virtual-devices",
               "remote-desktop-vdi/macstadium-vdi-deployment/validation-and-testing",
               "remote-desktop-vdi/macstadium-vdi-deployment/production-rollout",
               "remote-desktop-vdi/macstadium-vdi-deployment/business-outcomes-use-cases",

--- a/remote-desktop-vdi/macstadium-vdi-deployment/android-virtual-devices.mdx
+++ b/remote-desktop-vdi/macstadium-vdi-deployment/android-virtual-devices.mdx
@@ -1,0 +1,161 @@
+---
+title: "Android Virtual Devices"
+description: "Run Android emulators natively on Apple Silicon host nodes alongside MacStadium VDI macOS desktops, with automatic ADB connectivity to your VM."
+---
+
+Mobile developers using MacStadium VDI often need Android emulator access alongside their macOS desktop for testing, debugging, or running Android apps in parallel with their Citrix-managed session.
+
+Android emulators cannot run inside a macOS virtual machine. The Apple Virtualization Framework does not support nested virtualization, so the emulator has no access to the hardware hypervisor it requires. Running an emulator inside a VM is not a supported path.
+
+MacStadium VDI solves this by running the Android emulator natively on the Apple Silicon host node, on the same physical machine as your macOS VM. An ADB relay is automatically configured between the host-side emulator and your VM, so your desktop session can reach the Android device over ADB without manual network setup or a third-party emulator service.
+
+## Prerequisites
+
+Before setting up Android Virtual Devices, ensure:
+
+- MacStadium VDI is deployed and operational (see the [Deployment Guide](/remote-desktop-vdi/macstadium-vdi-deployment/deployment-guide))
+- Ansible runner has `sshpass` installed
+- The target macOS VM is running on a host node where the Android SDK will be installed
+
+## Install the Android SDK
+
+Run this on the Ansible runner to install the Android SDK on your host nodes. This installs:
+
+- Homebrew (if not already present)
+- Eclipse Temurin JDK 21
+- Android command-line tools, platform-tools, and emulator packages
+- `socat` (used to set up the ADB relay between the host and your VM)
+- A `run-avd` script at `/opt/orka/bin/run-avd`
+
+It also configures `JAVA_HOME`, `ANDROID_HOME`, and `PATH` in the host's `.zshrc`.
+
+```bash
+ansible-playbook install_android_sdk.yml -i inventory
+```
+
+To force reinstallation on hosts where the SDK is already present:
+
+```bash
+ansible-playbook install_android_sdk.yml -i inventory -e "install_android_sdk_force=true"
+```
+
+## Install SDK Platforms and System Images
+
+Once the Android SDK is installed, install the platform and system images you want to use for your AVDs.
+
+```bash
+ansible-playbook sdkmanager_install.yml -i inventory
+```
+
+This installs platform `android-35` with `default` and `google_apis` system images by default. To specify a different platform or image types:
+
+```bash
+ansible-playbook sdkmanager_install.yml -i inventory -e "platform=android-34" -e "image_types=default,google_apis,google_apis_playstore"
+```
+
+Available variables:
+
+- `platform` — Android platform to install (default: `android-35`)
+- `image_types` — comma-separated list of system image types (default: `default,google_apis`)
+
+## Create an Android Virtual Device
+
+AVDs are tied to a specific VM. The AVD name is derived automatically from the VM name using the pattern `{vm_name}-avd-{index}`, where the index increments for each additional AVD on that VM (e.g. `my-vm-avd-0`, `my-vm-avd-1`).
+
+Run with `--tags plan` first to preview which host the AVD will be created on:
+
+```bash
+ansible-playbook deploy_avd.yml -i inventory -e "vm_name=my-vm" --tags plan
+```
+
+Then create the AVD:
+
+```bash
+ansible-playbook deploy_avd.yml -i inventory -e "vm_name=my-vm"
+```
+
+The playbook locates the host running the specified VM, determines the next available AVD index, creates the AVD, and sets up network connectivity between the host-side emulator and the VM.
+
+Available variables:
+
+- `vm_name` *(required)* — name of the running VM the AVD should be associated with
+- `platform` — Android platform to use (default: `android-35`)
+- `image_type` — system image type (default: `default`)
+- `run_avd` — whether to start the AVD immediately after creation (default: `true`)
+- `cpu` — vCPUs to allocate to the AVD
+- `memory` — memory in MB to allocate to the AVD
+
+Example with custom settings:
+
+```bash
+ansible-playbook deploy_avd.yml -i inventory -e "vm_name=my-vm" -e "platform=android-34" -e "image_type=google_apis" -e "cpu=4" -e "memory=2048"
+```
+
+## Manage Android Virtual Devices
+
+### Start, stop, or delete an AVD
+
+Use `avd.yml` to bring an AVD to a desired state. The playbook is idempotent - it will not attempt to start an already running AVD, stop an already stopped one, or delete one that does not exist.
+
+```bash
+ansible-playbook avd.yml -i inventory -e "vm_name=my-vm" -e "desired_state=running"
+```
+
+Valid values for `desired_state`: `running`, `stopped`, `absent`
+
+When only one AVD exists for a VM, it is selected automatically. If multiple AVDs exist, specify which one using `avd_index`:
+
+```bash
+ansible-playbook avd.yml -i inventory -e "vm_name=my-vm" -e "desired_state=absent" -e "avd_index=1"
+```
+
+To preview the planned action without making changes:
+
+```bash
+ansible-playbook avd.yml -i inventory -e "vm_name=my-vm" -e "desired_state=running" --tags plan
+```
+
+### List AVDs
+
+To list all AVDs across all hosts:
+
+```bash
+ansible-playbook list_avds.yml -i inventory
+```
+
+To filter by VM:
+
+```bash
+ansible-playbook list_avds.yml -i inventory -e "vm_name=my-vm"
+```
+
+Each AVD is displayed with its host and status. Running AVDs include additional details: PID, gateway IP, and ADB relay port.
+
+### Delete an AVD
+
+To delete a specific AVD by index:
+
+```bash
+ansible-playbook delete_avd.yml -i inventory -e "vm_name=my-vm" -e "avd_index=0"
+```
+
+If the AVD is currently running, the playbook stops it before deleting.
+
+Required variables:
+
+- `vm_name` — name of the VM the AVD is associated with
+- `avd_index` — index of the AVD to delete (e.g. `0` for `my-vm-avd-0`)
+
+## Uninstall SDK Platforms and System Images
+
+To uninstall a specific platform and all of its system images from host nodes:
+
+```bash
+ansible-playbook sdkmanager_uninstall.yml -i inventory
+```
+
+This uninstalls `android-35` by default. To target a different platform:
+
+```bash
+ansible-playbook sdkmanager_uninstall.yml -i inventory -e "platform=android-34"
+```

--- a/remote-desktop-vdi/macstadium-vdi-deployment/ansible-playbook-implementation.mdx
+++ b/remote-desktop-vdi/macstadium-vdi-deployment/ansible-playbook-implementation.mdx
@@ -39,10 +39,10 @@ Playbooks eliminate manual work by automating repetitive tasks, ensuring consist
     
 ```
 # Plan deployment (dry-run)
-ansible-playbook -i inventory deploy.yml -e "vm_group=citrix-vda" -e "desired_vms=1" --tags plan
+ansible-playbook -i inventory deploy.yml -e "vm_name=citrix-vda-01" -e "vm_image=<your-image>" --tags plan
 
 # Execute deployment
-ansible-playbook -i inventory deploy.yml -e "vm_group=citrix-vda" -e "desired_vms=1" 
+ansible-playbook -i inventory deploy.yml -e "vm_name=citrix-vda-01" -e "vm_image=<your-image>"
 ```
 #### Delete a single VM 
     
@@ -50,17 +50,19 @@ ansible-playbook -i inventory deploy.yml -e "vm_group=citrix-vda" -e "desired_vm
 ```
 ansible-playbook -i inventory vm.yml -e "vm_name=citrix-vda-abc123" -e "desired_state=absent"
 ```
-#### Delete multiple VMs matching a specific naming convention
+#### Delete a VM by name
     
     
 ```
 # Plan deletion (dry-run)
-ansible-playbook -i inventory delete.yml -e "vm_group=citrix-vda-test" -e "delete_count=5" --tags plan
+ansible-playbook -i inventory delete.yml -e "vm_name=citrix-vda-test-01" --tags plan
 
 # Execute deletion
-ansible-playbook -i inventory delete.yml -e "vm_group=citrix-vda-test" -e "delete_count=5"
+ansible-playbook -i inventory delete.yml -e "vm_name=citrix-vda-test-01"
 ```
-Note: This deletes a defined number of VMs from the group with that name. To delete a VM on a specific host, use:
+_Run this command once for each VM to remove._
+
+To delete a VM on a specific host, use:
     
     
 ```
@@ -138,7 +140,7 @@ Provisions a new admin user account on a running VM. The playbook connects to th
 ansible-playbook -i inventory provision_user.yml -e "vm_name=<vm_name>" -e "vm_username=<existing_admin_username>" -e "vm_password=<existing_admin_password>" -e "new_username=<new_username>" -e "new_user_password=<new_user_password>"
 ```
 
-The playbook is idempotent — if the user already exists it will skip creation.
+The playbook is idempotent. If the user already exists it will skip creation.
 
 #### Install Citrix VDA
 

--- a/remote-desktop-vdi/macstadium-vdi-deployment/business-outcomes-use-cases.mdx
+++ b/remote-desktop-vdi/macstadium-vdi-deployment/business-outcomes-use-cases.mdx
@@ -18,7 +18,7 @@ _"We have contractors in one-off locations and in other countries where we are h
 
 #### Security Risks
 
-Physical Mac endpoints are vulnerable to theft, loss, and unauthorized access. Traditional Mobile Device Management (MDM) solutions have limitations—data still resides on the device, policies can be bypassed by savvy users, and protection depends on internet connectivity.
+Physical Mac endpoints are vulnerable to theft, loss, and unauthorized access. Traditional Mobile Device Management (MDM) solutions have limitations: data still resides on the device, policies can be bypassed by savvy users, and protection depends on internet connectivity.
 
 Organizations with data sovereignty requirements face additional challenges ensuring that sensitive information remains within specific geographic boundaries.
 
@@ -83,9 +83,15 @@ Media rendering, complex iOS builds, AI/ML workloads, and other compute-intensiv
 
 **Learn more:** [Investing in High-Performance Apple Hardware](https://www.macstadium.com/blog/citrix-macstadium-investing-in-high-performance-apple-hardware)
 
+#### Mobile Developers Requiring Android Testing
+
+Mobile developers building cross-platform apps need Android emulator access alongside their macOS desktop. Because Android emulators require bare-metal hardware virtualization, they cannot run inside a macOS VM. MacStadium VDI solves this by running the Android emulator natively on the Apple Silicon host node (the same physical machine as the macOS VM) and establishing an ADB relay between the host-side emulator and the developer's Citrix session. The result is a single desktop experience with both macOS and Android accessible without leaving the VDI session.
+
+**Learn more:** [Android Virtual Devices](/remote-desktop-vdi/macstadium-vdi-deployment/android-virtual-devices)
+
 ### Why Choose MacStadium for Citrix VDI?
 
-**Genuine Apple Hardware:** MacStadium provides access to authentic Mac mini and Studio hardware in cloud compute environments—no emulation, no compromises. [View available models](https://www.macstadium.com/bare-metal-mac).
+**Genuine Apple Hardware:** MacStadium provides access to authentic Mac mini and Studio hardware in cloud compute environments, with no emulation and no compromises. [View available models](https://www.macstadium.com/bare-metal-mac).
 
 **Proven Citrix Technology:** Leverage HDX protocol, established security posture, SSO/MFA integration, and the familiar Citrix administration experience your team already knows.
 

--- a/remote-desktop-vdi/macstadium-vdi-deployment/citrix-daas-configuration.mdx
+++ b/remote-desktop-vdi/macstadium-vdi-deployment/citrix-daas-configuration.mdx
@@ -389,14 +389,14 @@ For pilot deployments or troubleshooting:
        ```bash
        # Plan deployment (dry-run)
        ansible-playbook -i inventory deploy.yml \
-         -e "vm_group=citrix-vda-test" \
-         -e "desired_vms=1" \
+         -e "vm_name=citrix-vda-test-01" \
+         -e "vm_image=<your-image>" \
          --tags plan
 
        # Execute deployment
        ansible-playbook -i inventory deploy.yml \
-         -e "vm_group=citrix-vda-test" \
-         -e "desired_vms=1"
+         -e "vm_name=citrix-vda-test-01" \
+         -e "vm_image=<your-image>"
        ```
 
      - Allocate appropriate VM resources (CPU, RAM, storage)

--- a/remote-desktop-vdi/macstadium-vdi-deployment/deployment-guide.mdx
+++ b/remote-desktop-vdi/macstadium-vdi-deployment/deployment-guide.mdx
@@ -6,7 +6,7 @@ zendesk_id: 44259626250267
 
 ## Overview
 
-This guide walks through the full setup of Orka Engine Orchestration for VDI deployments. It covers network preparation, controller and host configuration, Orka Engine installation, VM deployment, and the optional Semaphore web interface.
+This guide walks through the full setup of Orka Engine Orchestration for VDI deployments. It covers network preparation, controller and host configuration, Orka Engine installation, VM deployment, and the Semaphore web interface.
 
 There are three roles in this setup:
 
@@ -303,24 +303,26 @@ All playbook commands are run from the controller inside ~/orka-automation/orka-
 
 **Run on: Controller**
 
-Deploy a group of VMs. The `vm_group` name is used to track and manage the VMs as a set.
+Deploy a VM by name. Run once per VM to deploy multiple.
 
 ```
-ansible-playbook deploy.yml -i inventory -e "vm_group=vdi-group" -e "desired_vms=4"
+ansible-playbook deploy.yml -i inventory -e "vm_name=vdi-group-01" -e "vm_image=<your-image>"
 ```
 
 For VDI workloads, use bridged networking so VMs receive IP addresses directly on your LAN. Specify the network interface (typically `en0` for Ethernet):
 
 ```
-ansible-playbook deploy.yml -i inventory -e "vm_group=vdi-group" -e "desired_vms=4" -e "network_interface=en0"
+ansible-playbook deploy.yml -i inventory -e "vm_name=vdi-group-01" -e "vm_image=<your-image>" -e "network_interface=en0"
 ```
+
+_Run this command once for each additional VM, using a unique `vm_name` each time._
 
 **Note:\*\*** \*\*When network_interface is not specified, VMs deploy in NAT mode. Bridged mode is recommended for VDI because VMs are directly reachable by Citrix Cloud and end users without port forwarding.
 
 To preview what will be deployed without making any changes, add `--tags plan`:
 
 ```
-ansible-playbook deploy.yml -i inventory -e "vm_group=vdi-group" -e "desired_vms=4" --tags plan
+ansible-playbook deploy.yml -i inventory -e "vm_name=vdi-group-01" -e "vm_image=<your-image>" --tags plan
 ```
 
 ### 6.2  List VMs
@@ -328,7 +330,7 @@ ansible-playbook deploy.yml -i inventory -e "vm_group=vdi-group" -e "desired_vms
 **Run on: Controller**
 
 ```
-ansible-playbook list.yml -i inventory -e "vm_group=vdi-group"
+ansible-playbook list.yml -i inventory -e "vm_name=vdi-group"
 ```
 
 ### 6.3  Manage Individual VMs
@@ -345,11 +347,13 @@ ansible-playbook vm.yml -i inventory -e "vm_name=my-vm-name" -e "desired_state=r
 
 **Run on: Controller**
 
-Delete a specific number of VMs from a group. Add --tags plan to preview before deleting.
+Delete a VM by name.
 
 ```
-ansible-playbook delete.yml -i inventory -e "vm_group=vdi-group" -e "delete_count=2"
+ansible-playbook delete.yml -i inventory -e "vm_name=vdi-group-01"
 ```
+
+_Run this command once for each VM to remove._
 
 ### 6.5  Pull Images
 
@@ -361,9 +365,9 @@ Pre-pull an image to all hosts so it is ready for fast deployment:
 ansible-playbook pull_image.yml -i inventory -e "remote_image_name=ghcr.io/macstadium/orka-images/sequoia:latest"
 ```
 
-## 7.  Semaphore Web UI (Optional)
+## 7.  Semaphore Web UI
 
-Semaphore provides a browser-based interface for running orchestration playbooks without CLI access. All task templates, inventory, and repository configuration are set up automatically on first launch.
+Semaphore provides a browser-based interface for running orchestration playbooks. It is the primary way IT administrators interact with MacStadium VDI. The CLI is available for troubleshooting and advanced or custom workflows. All task templates, inventory, and repository configuration are set up automatically on first launch.
 
 ### 7.1  Install Prerequisites
 
@@ -432,9 +436,9 @@ Semaphore is available at `http://localhost:3000`. Log in with the admin credent
 
 You can configure SSH credentials either via the setup script or manually through the Semaphore UI.
 
-**Option A — Setup script (recommended)**
+**Option A: Setup script (recommended)**
 
-`uv` is required to run this script — it’s a lightweight Python package manager used to execute the configuration script without managing a virtual environment manually. It handles SSH key setup and optionally sets default VM credentials and OCI registry credentials in one step.
+`uv` is required to run this script. It is a lightweight Python package manager that executes the configuration script without requiring a virtual environment. It handles SSH key setup and optionally sets default VM credentials and OCI registry credentials in one step.
 
 ```bash
 SEMAPHORE_ADMIN=$YOUR_ADMIN SEMAPHORE_ADMIN_PASSWORD=$YOUR_ADMIN_PASSWORD uv run ./semaphore/configure_semaphore.py --ssh-key-file $YOUR_KEY
@@ -442,7 +446,7 @@ SEMAPHORE_ADMIN=$YOUR_ADMIN SEMAPHORE_ADMIN_PASSWORD=$YOUR_ADMIN_PASSWORD uv run
 
 Run `uv run ./semaphore/configure_semaphore.py --help` to see additional parameters, including default VM username/password and OCI registry credentials.
 
-**Option B — Manual (UI)**
+**Option B: Manual (UI)**
 
 After logging in, navigate to **Key Store** and edit the Mac Hosts SSH key. Replace the placeholder credentials with the actual SSH username and private key (or password) for your Mac hosts.
 

--- a/remote-desktop-vdi/macstadium-vdi-deployment/image-management.mdx
+++ b/remote-desktop-vdi/macstadium-vdi-deployment/image-management.mdx
@@ -44,7 +44,7 @@ This implementation doesn’t have a dedicated playbook. To refresh VMs with a n
 ansible-playbook -i inventory vm.yml -e "vm_name=citrix-vda-abc123" -e "desired_state=absent"
 
 # Step 2: Deploy a replacement VM from the new image version 
-ansible-playbook -i inventory deploy.yml -e "vm_group=citrix-vda" -e "desired_vms=1" -e "vm_image=registry.example.com/citrix-vda/sonoma-golden:v2.0"
+ansible-playbook -i inventory deploy.yml -e "vm_name=citrix-vda-01" -e "vm_image=registry.example.com/citrix-vda/sonoma-golden:v2.0"
 ```
 ## Cache management
 

--- a/remote-desktop-vdi/macstadium-vdi-deployment/jamf-enrollment.mdx
+++ b/remote-desktop-vdi/macstadium-vdi-deployment/jamf-enrollment.mdx
@@ -55,7 +55,7 @@ Enrollment invitations in Jamf Pro 11 live under Computers, but may be inside th
 
 1. Click **Computers** at the top of the left sidebar.
 2. Click **Enrollment Invitations** in the sidebar.
-3. Click **New** and follow the prompts. Set the expiration date as far out as your instance allows — align it to your image rotation schedule so the invitation doesn't go stale before you re-seal the image.
+3. Click **New** and follow the prompts. Set the expiration date as far out as your instance allows, and align it to your image rotation schedule so the invitation does not go stale before you re-seal the image.
 4. Scope the invitation to a specific Jamf site or LDAP group if needed.
 5. After saving, open the invitation record and copy the **Invitation ID**. This is the value you'll use as `INVITATION_CODE` in both scripts below.
 
@@ -242,7 +242,7 @@ chmod 644 /Library/LaunchAgents/com.yourcompany.jamf-enroll-prompt.plist
 
 ### Step 7: Seal the Golden Image
 
-1. Don't load the LaunchDaemon or LaunchAgent in the image itself — they load on first boot and first login of each provisioned VM.
+1. Don't load the LaunchDaemon or LaunchAgent in the image itself. They load on first boot and first login of each provisioned VM.
 2. Confirm no MDM profile is already enrolled: `profiles status -type enrollment` should return "MDM enrollment: No".
 3. Confirm no Jamf management framework is already installed. If `/Library/Application Support/JAMF/` exists, remove it before sealing: `sudo rm -rf "/Library/Application Support/JAMF/"`.
 4. Publish the image in Orka.
@@ -267,7 +267,7 @@ In Jamf Pro, go to **Computers > Search Computers** and search for the VM by hos
 
 ## A Few Things Worth Knowing
 
-**Each VM gets its own record.** Orka assigns each VM a unique hardware UUID, so every desktop shows up as a separate computer in Jamf. When you destroy and reprovision a VM, the new instance creates a new record. Stale records from old VMs stick around until you clean them up manually — plan for that if you're running a high-churn environment.
+**Each VM gets its own record.** Orka assigns each VM a unique hardware UUID, so every desktop shows up as a separate computer in Jamf. When you destroy and reprovision a VM, the new instance creates a new record. Stale records from old VMs stick around until you clean them up manually, so plan for that if you're running a high-churn environment.
 
 **Watch your invitation expiry.** If the enrollment invitation expires, the script hits its retry limit and stops trying. For long-lived golden images, set the invitation to "Never Expires." If you rotate invitations, update the script and re-seal the image before the old code goes stale.
 

--- a/remote-desktop-vdi/macstadium-vdi-deployment/production-rollout.mdx
+++ b/remote-desktop-vdi/macstadium-vdi-deployment/production-rollout.mdx
@@ -568,8 +568,9 @@ As your user base grows, you may wish to add more Orka hosts:
     
     
 ```
-ansible-playbook -i inventory deploy.yml -e "vm_group=citrix-vda-finance" -e "desired_vms=40" -e "vm_image=registry.example.com/citrix-vda/sonoma-finance:latest"
+ansible-playbook -i inventory deploy.yml -e "vm_name=citrix-vda-finance-01" -e "vm_image=registry.example.com/citrix-vda/sonoma-finance:latest"
 ```
+_Run this command once for each additional VM, using a unique `vm_name` each time._
 **Vertical scaling (increase VM resources):**
 
 If users need more powerful desktops, upgrade to higher-spec Macs:

--- a/remote-desktop-vdi/macstadium-vdi-deployment/validation-and-testing.mdx
+++ b/remote-desktop-vdi/macstadium-vdi-deployment/validation-and-testing.mdx
@@ -36,7 +36,9 @@ This test validates the complete user journey from authentication to desktop usa
   1. Deploy 2-3 test VMs from your golden image, for example:
          
 ```
-     ansible-playbook -i inventory deploy.yml -e "vm_group=citrix-test" -e "desired_vms=3" -e "vm_image=registry.example.com/citrix-vda/sonoma-finance:latest"
+     ansible-playbook -i inventory deploy.yml -e "vm_name=citrix-test-01" -e "vm_image=registry.example.com/citrix-vda/sonoma-finance:latest"
+     ansible-playbook -i inventory deploy.yml -e "vm_name=citrix-test-02" -e "vm_image=registry.example.com/citrix-vda/sonoma-finance:latest"
+     ansible-playbook -i inventory deploy.yml -e "vm_name=citrix-test-03" -e "vm_image=registry.example.com/citrix-vda/sonoma-finance:latest"
 ```
   2. Verify VDA registration via the Citrix Cloud Console. Navigate to Manage → Virtual Apps and Desktops → Delivery Groups and confirm the VMs appear with a Registered status.
 
@@ -352,7 +354,7 @@ These operations form the foundation of desktop pool management with MacStadium 
   1. Deploy VM from a golden image:
          
 ```
-     ansible-playbook -i inventory deploy.yml -e "vm_group=lifecycle-test" -e "desired_vms=1" -e "vm_image=registry.example.com/citrix-vda/sonoma-finance:latest"
+     ansible-playbook -i inventory deploy.yml -e "vm_name=lifecycle-test-01" -e "vm_image=registry.example.com/citrix-vda/sonoma-finance:latest"
 ```
 After the VM has been deployed, you will want to confirm the VM has received an IP address from DHCP, it is accessible via SSH, the VDA service has started automatically and has been registered with Citrix Cloud, the desktop appears in Citrix Workspace, and users can successfully launch a session. You may also wish to record the amount of time it takes to complete this workflow from the time launch commands are executed to desktop availability.  
 
@@ -394,7 +396,7 @@ To recover a VM:
 Example: 
          
 ```
-     ansible-playbook -i inventory deploy.yml -e "vm_group=recovered-vm" -e "desired_vms=1" -e "vm_image=registry.example.com/backups/sonoma-finance:2025-01-15"
+     ansible-playbook -i inventory deploy.yml -e "vm_name=recovered-vm-01" -e "vm_image=registry.example.com/backups/sonoma-finance:2025-01-15"
 ```
 You will want to confirm that the VM has been recovered from backup, retains its configuration from the backup point, the VDA re-registers successfully, and the desktop is functional.  
   
@@ -454,3 +456,70 @@ Some metrics to consider measuring are:
 
  4. What is the average network bandwidth per session?
 ```
+
+#### Android Virtual Device validation
+
+If your deployment includes Android Virtual Devices, validate the AVD setup before production use.
+
+##### AVD creation and status
+
+  1. Create an AVD for a running VM:
+
+```bash
+ansible-playbook -i inventory deploy_avd.yml -e "vm_name=citrix-test-01"
+```
+
+  2. Confirm the AVD appears in the list with a running status:
+
+```bash
+ansible-playbook -i inventory list_avds.yml -e "vm_name=citrix-test-01"
+```
+
+**Expected result:** AVD listed with status `running`, host, and ADB relay port visible.
+
+##### ADB connectivity from the VM
+
+  1. Inside the Citrix desktop session on `citrix-test-01`, open Terminal.
+
+  2. List connected Android devices:
+
+```bash
+adb devices
+```
+
+**Expected result:** The host-side emulator appears as a connected device (e.g. `emulator-5554 device`).
+
+  3. Confirm ADB shell access:
+
+```bash
+adb shell getprop ro.build.version.release
+```
+
+**Expected result:** Android version string returned without error.
+
+##### ADB relay port reachability
+
+  1. From within the VM, verify the relay port is reachable. The default relay port is shown in the `list_avds.yml` output.
+
+```bash
+nc -zv localhost <relay_port>
+```
+
+**Expected result:** Connection succeeds (`Connection to localhost <relay_port> port [tcp/*] succeeded`).
+
+##### AVD lifecycle
+
+  1. Stop the AVD and confirm it is no longer listed as running:
+
+```bash
+ansible-playbook -i inventory avd.yml -e "vm_name=citrix-test-01" -e "desired_state=stopped"
+ansible-playbook -i inventory list_avds.yml -e "vm_name=citrix-test-01"
+```
+
+  2. Restart the AVD and re-verify ADB connectivity from the VM:
+
+```bash
+ansible-playbook -i inventory avd.yml -e "vm_name=citrix-test-01" -e "desired_state=running"
+```
+
+**Expected result:** AVD restarts cleanly, ADB reconnects automatically, relay port is reachable again.

--- a/remote-desktop-vdi/operational-guides/ansible-quick-reference.mdx
+++ b/remote-desktop-vdi/operational-guides/ansible-quick-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Ansible Quick Reference"
-description: "Quick-reference Ansible commands for Orka-based Citrix VDI: connectivity tests, Orka Engine version checks, VM lifecycle, VDA management, and image ops."
+description: "Quick-reference Ansible commands for Orka-based Citrix VDI: connectivity tests, Orka Engine version checks, VM lifecycle, VDA management, image ops, and Android Virtual Devices."
 zendesk_id: 44260146530715
 ---
 
@@ -32,7 +32,7 @@ ansible hosts -i /inventory -m shell -a "python3 --version"
     
     
 ```
-ansible-playbook -i /inventory install-engine.yml \
+ansible-playbook -i /inventory install_engine.yml \
   -e "orka_license_key=YOUR_KEY" \
   -e "engine_url=https://download.url/orka-engine"
 ```
@@ -41,41 +41,38 @@ ansible-playbook -i /inventory install-engine.yml \
     
 ```
 ansible-playbook -i /inventory deploy.yml \
-  -e "vm_group=webapp" \
-  -e "desired_vms=10" \
+  -e "vm_name=my-vm" \
   --tags plan
 ```
-### Deploy VM Group
+### Deploy VM
     
     
 ```
 ansible-playbook -i /inventory deploy.yml \
-  -e "vm_group=webapp" \
-  -e "desired_vms=10"
+  -e "vm_name=my-vm" \
+  -e "vm_image=ghcr.io/macstadium/orka-images/sonoma:latest"
 ```
 ### Plan Deletion (Dry Run)
     
     
 ```
 ansible-playbook -i /inventory delete.yml \
-  -e "vm_group=webapp" \
-  -e "delete_count=5" \
+  -e "vm_name=my-vm" \
   --tags plan
 ```
-### Delete VM Group
+### Delete VM
     
     
 ```
 ansible-playbook -i /inventory delete.yml \
-  -e "vm_group=webapp" \
-  -e "delete_count=5"
+  -e "vm_name=my-vm"
 ```
 ### Stop VM
     
     
 ```
 ansible-playbook -i /inventory vm.yml \
-  -e "vm_name=webapp-abc123" \
+  -e "vm_name=my-vm" \
   -e "desired_state=stopped"
 ```
 ### Start VM
@@ -83,7 +80,7 @@ ansible-playbook -i /inventory vm.yml \
     
 ```
 ansible-playbook -i /inventory vm.yml \
-  -e "vm_name=webapp-abc123" \
+  -e "vm_name=my-vm" \
   -e "desired_state=running"
 ```
 ### Delete Single VM
@@ -91,7 +88,7 @@ ansible-playbook -i /inventory vm.yml \
     
 ```
 ansible-playbook -i /inventory vm.yml \
-  -e "vm_name=webapp-abc123" \
+  -e "vm_name=my-vm" \
   -e "desired_state=absent"
 ```
 ### List All VMs
@@ -100,11 +97,11 @@ ansible-playbook -i /inventory vm.yml \
 ```
 ansible-playbook -i /inventory list.yml
 ```
-### List VMs from Group
+### List VMs by Name
     
     
 ```
-ansible-playbook -i /inventory list.yml -e "vm_group=webapp"
+ansible-playbook -i /inventory list.yml -e "vm_name=my-vm"
 ```
 ### Pull Image to All Hosts
     
@@ -132,34 +129,140 @@ ansible-playbook -i /inventory create_image.yml \
 ```
 * * *
 
+## Android Virtual Devices
+
+### Install Android SDK on Hosts
+    
+    
+```
+ansible-playbook -i /inventory install_android_sdk.yml
+```
+
+To force reinstallation on hosts where the SDK is already present:
+
+```
+ansible-playbook -i /inventory install_android_sdk.yml \
+  -e "install_android_sdk_force=true"
+```
+### Install SDK Platforms and System Images
+    
+    
+```
+ansible-playbook -i /inventory sdkmanager_install.yml
+```
+
+With a specific platform and image types:
+
+```
+ansible-playbook -i /inventory sdkmanager_install.yml \
+  -e "platform=android-34" \
+  -e "image_types=default,google_apis,google_apis_playstore"
+```
+### Create an AVD (Plan First)
+    
+    
+```
+ansible-playbook -i /inventory deploy_avd.yml \
+  -e "vm_name=my-vm" \
+  --tags plan
+```
+### Create an AVD
+    
+    
+```
+ansible-playbook -i /inventory deploy_avd.yml \
+  -e "vm_name=my-vm"
+```
+
+With custom platform, image type, and resources:
+
+```
+ansible-playbook -i /inventory deploy_avd.yml \
+  -e "vm_name=my-vm" \
+  -e "platform=android-34" \
+  -e "image_type=google_apis" \
+  -e "cpu=4" \
+  -e "memory=2048"
+```
+### Manage AVD State
+    
+    
+```
+# Start AVD
+ansible-playbook -i /inventory avd.yml \
+  -e "vm_name=my-vm" \
+  -e "desired_state=running"
+
+# Stop AVD
+ansible-playbook -i /inventory avd.yml \
+  -e "vm_name=my-vm" \
+  -e "desired_state=stopped"
+
+# Delete AVD (specify index if multiple exist)
+ansible-playbook -i /inventory avd.yml \
+  -e "vm_name=my-vm" \
+  -e "desired_state=absent" \
+  -e "avd_index=0"
+```
+### List AVDs
+    
+    
+```
+# All AVDs across all hosts
+ansible-playbook -i /inventory list_avds.yml
+
+# Filter by VM
+ansible-playbook -i /inventory list_avds.yml -e "vm_name=my-vm"
+```
+### Delete AVD by Index
+    
+    
+```
+ansible-playbook -i /inventory delete_avd.yml \
+  -e "vm_name=my-vm" \
+  -e "avd_index=0"
+```
+### Uninstall SDK Platform
+    
+    
+```
+ansible-playbook -i /inventory sdkmanager_uninstall.yml
+
+# Target a specific platform
+ansible-playbook -i /inventory sdkmanager_uninstall.yml \
+  -e "platform=android-34"
+```
+* * *
+
 ## Common Variable Combinations
 
-### Small Development Group
+### Deploy with Custom CPU and Memory
     
     
 ```
 ansible-playbook -i inventory deploy.yml \
-  -e "vm_group=dev" \
-  -e "desired_vms=5" \
-  -e "max_vms_per_host=2"
+  -e "vm_name=dev-desktop" \
+  -e "vm_image=ghcr.io/macstadium/orka-images/sonoma:latest" \
+  -e "cpu=4" \
+  -e "memory=8192"
 ```
-### Medium Production Group
+### Deploy with Network Interface
     
     
 ```
 ansible-playbook -i inventory deploy.yml \
-  -e "vm_group=prod-webapp" \
-  -e "desired_vms=20" \
-  -e "max_vms_per_host=5"
+  -e "vm_name=prod-desktop" \
+  -e "vm_image=ghcr.io/macstadium/orka-images/sonoma:latest" \
+  -e "network_interface=en0"
 ```
-### Large-Scale Deployment
+### Deploy to Specific Host
     
     
 ```
 ansible-playbook -i inventory deploy.yml \
-  -e "vm_group=build-farm" \
-  -e "desired_vms=100" \
-  -e "max_vms_per_host=10"
+  -e "vm_name=build-01" \
+  -e "vm_image=ghcr.io/macstadium/orka-images/sonoma:latest" \
+  --limit mac-node-1
 ```
 ### Image Creation with Auth
     
@@ -203,11 +306,15 @@ ansible-playbook -i inventory pull_image.yml \
 
 ### VM Naming Convention
 
-VMs are automatically named with group prefix:
+VMs are identified individually by name. Use clear, descriptive names:
 
-  * Group `webapp` → VMs: `webapp-abc123`, `webapp-def456`, etc.
+  * `dev-desktop-01`, `dev-desktop-02`
 
-  * Group `dev` → VMs: `dev-xyz789`, `dev-uvw456`, etc.
+  * `prod-build-runner`, `prod-build-runner-2`
+
+  * `ci-macOS-sonoma`
+
+AVDs are named automatically based on the VM: `{vm_name}-avd-0`, `{vm_name}-avd-1`, etc.
 
 
 
@@ -282,11 +389,11 @@ ansible-playbook -i /inventory <playbook.yml> --step
 
 ### Naming & Organization
 
-  * Use meaningful VM group names (e.g., `webapp-prod`, `build-farm-dev`)
+  * Use clear, descriptive VM names (e.g., `prod-desktop-01`, `build-runner-sonoma`)
 
   * Version your images with tags (`:v1.0`, `:v2.0`, not `:latest` in prod)
 
-  * Document group purposes in inventory comments
+  * Document VM purposes in inventory comments
 
 
 
@@ -334,9 +441,7 @@ ansible-playbook -i /inventory <playbook.yml> --step
 
 ### State & Tracking
 
-  * Let Ansible manage VM counts (incremental deployment)
-
-  * Don't manually create VMs in managed groups
+  * Let Ansible manage VMs (use playbooks, not manual creation)
 
   * Use `list.yml` to verify state before changes
 

--- a/remote-desktop-vdi/operational-guides/day-2-operations-guide.mdx
+++ b/remote-desktop-vdi/operational-guides/day-2-operations-guide.mdx
@@ -158,8 +158,7 @@ Repeat this for each image your environment uses. This prevents slow first deplo
          
 ```
      ansible-playbook -i inventory deploy.yml \
-       -e "vm_group=test-new-host" \
-       -e "desired_vms=1" \
+       -e "vm_name=test-new-host-01" \
        -e "vm_image=registry.example.com/citrix-vda/sonoma-finance:v2.0" \
        --limit mac-node-4
 ```
@@ -168,8 +167,7 @@ Verify the test VM boots, registers with Citrix VDA, and is accessible. Once thi
          
 ```
      ansible-playbook -i inventory delete.yml \
-       -e "vm_group=test-new-host" \
-       -e "delete_count=1"
+       -e "vm_name=test-new-host-01"
 ```
   7. Deploy production VMs  
   
@@ -178,9 +176,11 @@ With your new host successfully verified, you can now deploy additional desktops
          
 ```
      ansible-playbook -i inventory deploy.yml \
-       -e "vm_group=citrix-vda-finance" \
-       -e "desired_vms=15"
+       -e "vm_name=citrix-vda-finance-01" \
+       -e "vm_image=registry.example.com/citrix-vda/sonoma-finance:latest"
 ```
+_Run this command once for each additional VM, using a unique `vm_name` each time._
+
 This may take anywhere between 2-4 hours for full host integration and testing.
 
 
@@ -222,10 +222,10 @@ You will want to note all VM names running on the host you're removing.
        -e "vm_name=citrix-vda-finance-abc123" \
        -e "desired_state=absent"
      
-     # Redeploy VM group to desired count
+     # Redeploy VM
      ansible-playbook -i inventory deploy.yml \
-       -e "vm_group=citrix-vda-finance" \
-       -e "desired_vms=10"
+       -e "vm_name=citrix-vda-finance-new-01" \
+       -e "vm_image=registry.example.com/citrix-vda/sonoma-finance:latest"
 ```
 **Option B:** Snapshot and recreate VMs for dedicated desktops with user data.  
   
@@ -291,8 +291,7 @@ Recommended workflow:
          
 ```
      ansible-playbook -i inventory deploy.yml \
-       -e "vm_group=image-test" \
-       -e "desired_vms=1" \
+       -e "vm_name=image-test-01" \
        -e "vm_image=registry.example.com/citrix-vda/sonoma-finance:v2.0"
 ```
   2. Access the test VM and install updates  
@@ -338,17 +337,14 @@ Inside the VM:
 ```
 ansible-playbook -i inventory create_image.yml \
   -e "vm_image=registry.example.com/citrix-vda/sonoma-finance:v2.0" \
-  -e "remote_image_name=registry.example.com/citrix-vda/sonoma-finance:v2.1" \
-  -e "registry_username=deploy" \
-  -e "@vault_passwords.yml"
+  -e "remote_image_name=registry.example.com/citrix-vda/sonoma-finance:v2.1"
 ```
   4. Delete the test VM  
 
          
 ```
      ansible-playbook -i inventory delete.yml \
-       -e "vm_group=image-test" \
-       -e "delete_count=1"
+       -e "vm_name=image-test-01"
 ```
 ##### Pilot update rollout
 
@@ -358,10 +354,10 @@ You may want to deploy the updated image to a small group of users first, as see
     
 ```
 ansible-playbook -i inventory deploy.yml \
-  -e "vm_group=citrix-vda-finance-pilot" \
-  -e "desired_vms=5" \
+  -e "vm_name=citrix-vda-finance-pilot-01" \
   -e "vm_image=registry.example.com/citrix-vda/sonoma-finance:v2.1"
 ```
+_Run this command once for each additional pilot VM, using a unique `vm_name` each time._
 You will want to monitor the updated image deployment for 3-5 business days, collecting user feedback on any new issues or errors, performance changes, and application compatibility issues that may arise.
 
 ##### Full production rollout
@@ -372,14 +368,16 @@ If the pilot succeeds, you can proceed to update all VMs in production. For pool
 ```
 # Delete existing VMs from finance group
 ansible-playbook -i inventory delete.yml \
-  -e "vm_group=citrix-vda-finance" \
-  -e "delete_count=10"
+  -e "vm_name=citrix-vda-finance-01"
+
+_Run this command once for each VM to remove._
 
 # Redeploy with new image version
 ansible-playbook -i inventory deploy.yml \
-  -e "vm_group=citrix-vda-finance" \
-  -e "desired_vms=10" \
+  -e "vm_name=citrix-vda-finance-01" \
   -e "vm_image=registry.example.com/citrix-vda/sonoma-finance:v2.1"
+
+_Run this command once for each additional VM, using a unique `vm_name` each time._
 ```
 You will want to schedule the update to take place during a scheduled maintenance window (evenings or weekends are recommended) to avoid user disruption.
 
@@ -457,15 +455,17 @@ Rollback plan: Keep the previous golden image version available for 30 days afte
     
 ```
 # Delete existing VMs from finance group
-ansible-playbook -i inventory-delete.yml \
-  -e "vm_group=citrix-vda-finance" \
-  -e "delete_count=10"
+ansible-playbook -i inventory delete.yml \
+  -e "vm_name=citrix-vda-finance-01"
+
+_Run this command once for each VM to remove._
 
 # Redeploy with previous image version (rollback)
-ansible-playbook -i inventory-deploy.yml \
-  -e "vm_group=citrix-vda-finance" \
-  -e "desired_vms=10" \
+ansible-playbook -i inventory deploy.yml \
+  -e "vm_name=citrix-vda-finance-01" \
   -e "vm_image=registry.example.com/citrix-vda/sonoma-finance:v2.0"
+
+_Run this command once for each additional VM, using a unique `vm_name` each time._
 ```
 ### User Lifecycle
 
@@ -502,8 +502,12 @@ Compare the listed VM count against the number of users in the Delivery Group. I
 ```
 # Add two more desktops
 ansible-playbook -i inventory deploy.yml \
-  -e "vm_group=citrix-vda-finance" \
-  -e "desired_vms=12"
+  -e "vm_name=citrix-vda-finance-11" \
+  -e "vm_image=registry.example.com/citrix-vda/sonoma-finance:latest"
+
+ansible-playbook -i inventory deploy.yml \
+  -e "vm_name=citrix-vda-finance-12" \
+  -e "vm_image=registry.example.com/citrix-vda/sonoma-finance:latest"
 ```
   3. User logs in
 
@@ -608,13 +612,17 @@ After offboarding multiple users, you may have excess VMs. If usage is consisten
     
 ```
 # List VMs in finance group
-ansible-playbook -i inventory list.yml \
-  -e "vm_group=citrix-vda-finance"
+ansible-playbook -i inventory list.yml | grep citrix-vda-finance
 
 # Delete 3 VMs from finance group
 ansible-playbook -i inventory delete.yml \
-  -e "vm_group=citrix-vda-finance" \
-  -e "delete_count=3"
+  -e "vm_name=citrix-vda-finance-10"
+
+ansible-playbook -i inventory delete.yml \
+  -e "vm_name=citrix-vda-finance-11"
+
+ansible-playbook -i inventory delete.yml \
+  -e "vm_name=citrix-vda-finance-12"
 ```
 ### Backup and Recovery
 
@@ -748,10 +756,10 @@ Prerequisites:
          
 ```
      ansible-playbook -i inventory-dr deploy.yml \
-       -e "vm_group=citrix-vda-finance" \
-       -e "desired_vms=10" \
+       -e "vm_name=citrix-vda-finance-01" \
        -e "vm_image=backup-registry.example.com/citrix-vda/sonoma-finance:v2.0"
 ```
+_Run this command once for each additional VM, using a unique `vm_name` each time._
   4. Update Citrix Cloud configuration
 
 
@@ -922,12 +930,11 @@ Important note: You **cannot** switch networking modes with VMs running.
 # List all VMs
 ansible-playbook -i inventory list.yml
 
-# Delete all VMs (adjust groups and counts as needed)
+# Delete all VMs
 ansible-playbook -i inventory delete.yml \
-  -e "vm_group=citrix-vda-finance" \
-  -e "delete_count=10"
+  -e "vm_name=citrix-vda-finance-01"
 
-# Repeat for each VM group in your environment
+_Run this command once for each VM to remove._
 ```
 Step 4: Apply configuration changes
 
@@ -944,10 +951,11 @@ Deploy your VMs normally. They will now use bridged networking automatically:
     
 ```
 ansible-playbook -i inventory deploy.yml \
-  -e "vm_group=citrix-vda-finance" \
-  -e "desired_vms=10" \
+  -e "vm_name=citrix-vda-finance-01" \
   -e "vm_image=registry.example.com/citrix-vda/sonoma-finance:v2.0"
 ```
+_Run this command once for each additional VM, using a unique `vm_name` each time._
+
 Step 6: Verify that VMs received DHCP addresses
     
     
@@ -1228,8 +1236,7 @@ Create a playbook that deploys a test VM, installs updates, and creates a new go
     - name: Deploy test VM
       command: >
         ansible-playbook -i inventory deploy.yml
-        -e "vm_group=image-test"
-        -e "desired_vms=1"
+        -e "vm_name=image-test-01"
         -e "vm_image={{ current_image }}"
 
     - name: Wait for VM to be ready
@@ -1250,8 +1257,7 @@ Create a playbook that deploys a test VM, installs updates, and creates a new go
     - name: Clean up test VM
       command: >
         ansible-playbook -i inventory delete.yml
-        -e "vm_group=image-test"
-        -e "delete_count=1"
+        -e "vm_name=image-test-01"
 ```
   2. Scheduled capacity scaling
 
@@ -1263,11 +1269,13 @@ Schedule a cron job to automatically scale capacity up during business hours and
     
 ```
 # Scale up at 7 AM weekdays
-0 7 * * 1-5 ansible-playbook -i /path/to/inventory deploy.yml -e "vm_group=citrix-vda-finance" -e "desired_vms=15"
+0 7 * * 1-5 /path/to/scale-up.sh
 
 # Scale down at 7 PM weekdays
-0 19 * * 1-5 ansible-playbook -i /path/to/inventory delete.yml -e "vm_group=citrix-vda-finance" -e "delete_count=5"
+0 19 * * 1-5 /path/to/scale-down.sh
 ```
+
+Where scale-up.sh deploys VMs with vm_name for each VM, and scale-down.sh deletes them by vm_name.
   3. Health check automation
 
 
@@ -1328,8 +1336,7 @@ jobs:
       - name: Deploy test VM
         run: |
           ansible-playbook -i inventory deploy.yml \
-            -e "vm_group=image-test" \
-            -e "desired_vms=1" \
+            -e "vm_name=image-test-01" \
             -e "vm_image=registry.example.com/citrix-vda/dev-base:latest"
 
       - name: Copy application to test VM
@@ -1353,9 +1360,9 @@ jobs:
       - name: Deploy to production
         run: |
           ansible-playbook -i inventory deploy.yml \
-            -e "vm_group=citrix-vda-dev" \
-            -e "desired_vms=20" \
+            -e "vm_name=citrix-vda-dev-01" \
             -e "vm_image=registry.example.com/citrix-vda/dev-tools:${{ github.sha }}"
+          # Repeat for each VM: vm_name=citrix-vda-dev-02, vm_name=citrix-vda-dev-03, etc. (20 total)
 ```
 This fully automates the process from code commit to production MacStadium VDI deployment.
 
@@ -1470,10 +1477,11 @@ Deploy tenant VMs only to their assigned hosts using `--limit`:
     
 ```
 ansible-playbook -i inventory deploy.yml \
-  -e "vm_group=citrix-vda-finance" \
-  -e "desired_vms=10" \
+  -e "vm_name=citrix-vda-finance-01" \
+  -e "vm_image=registry.example.com/citrix-vda/sonoma-finance:latest" \
   --limit finance_hosts
 ```
+_Run this command once for each additional VM, using a unique `vm_name` each time._
 Pros: Complete resource isolation, no noisy neighbor problems   
 Cons: Reduced flexibility, potential for underutilization
 
@@ -1488,10 +1496,10 @@ Track resources per tenant:
 # List VMs by group
 
 # Count finance VMs
-ansible-playbook -i inventory list.yml -e "vm_group=citrix-vda-finance" | wc -l
+ansible-playbook -i inventory list.yml | grep citrix-vda-finance | wc -l
 
 # Count engineering VMs
-ansible-playbook -i inventory list.yml -e "vm_group=citrix-vda-engineering" | wc -l
+ansible-playbook -i inventory list.yml | grep citrix-vda-engineering | wc -l
 ```
 Calculate costs:
 
@@ -1954,14 +1962,16 @@ If a new image causes issues within the first 24 hours:
 ```
 # Delete old VMs
 ansible-playbook -i inventory delete.yml \
-  -e "vm_group=citrix-vda-finance" \
-  -e "delete_count=10"
+  -e "vm_name=citrix-vda-finance-01"
+
+_Run this command once for each VM to remove._
 
 # Redeploy with previous version (rollback)
 ansible-playbook -i inventory deploy.yml \
-  -e "vm_group=citrix-vda-finance" \
-  -e "desired_vms=10" \
+  -e "vm_name=citrix-vda-finance-01" \
   -e "vm_image=registry.example.com/citrix-vda/sonoma-finance:v2.1"  # Previous version
+
+_Run this command once for each additional VM, using a unique `vm_name` each time._
 ```
   3. Verify users can connect to the now rolled-back VMs
 
@@ -2259,15 +2269,17 @@ ansible hosts -i inventory \
     
     
 ```
-# Deploy VMs
+# Deploy VM
 ansible-playbook -i inventory deploy.yml \
-  -e "vm_group=webapp" \
-  -e "desired_vms=10"
+  -e "vm_name=webapp-01" \
+  -e "vm_image=<your-image>"
+
+_Run this command once for each additional VM, using a unique `vm_name` each time._
 
 # Plan deployment (dry-run)
 ansible-playbook -i inventory deploy.yml \
-  -e "vm_group=webapp" \
-  -e "desired_vms=10" \
+  -e "vm_name=webapp-01" \
+  -e "vm_image=<your-image>" \
   --tags plan
 ```
 #### VM lifecycle:
@@ -2304,15 +2316,15 @@ ansible-playbook -i inventory vm.yml \
     
     
 ```
-# Delete VMs
+# Delete VM
 ansible-playbook -i inventory delete.yml \
-  -e "vm_group=webapp" \
-  -e "delete_count=5"
+  -e "vm_name=webapp-01"
+
+_Run this command once for each VM to remove._
 
 # Plan deletion (dry-run)
 ansible-playbook -i inventory delete.yml \
-  -e "vm_group=webapp" \
-  -e "delete_count=5" \
+  -e "vm_name=webapp-01" \
   --tags plan
 ```
 #### List VMs:
@@ -2322,9 +2334,8 @@ ansible-playbook -i inventory delete.yml \
 # List all VMs
 ansible-playbook -i inventory list.yml
 
-# List VMs in specific group
-ansible-playbook -i inventory list.yml \
-  -e "vm_group=webapp"
+# List VMs matching a name pattern
+ansible-playbook -i inventory list.yml -e "vm_name=webapp"
 ```
 #### Image operations:
     

--- a/remote-desktop-vdi/operational-guides/troubleshooting-quick-reference.mdx
+++ b/remote-desktop-vdi/operational-guides/troubleshooting-quick-reference.mdx
@@ -48,8 +48,7 @@ Quick diagnostic:
 
 ```bash
 ansible-playbook -i dev/inventory deploy.yml \
-  -e "vm_group=test" \
-  -e "desired_vms=1" \
+  -e "vm_name=test-01" \
   -e "vm_image=<image-name>" \
   -vvv
 
@@ -114,7 +113,7 @@ What you see:**** Requested 10 VMs but only 7 deployed, or deployment stopped pa
 Quick diagnostic:
 
 ```bash
-ansible-playbook -i dev/inventory list.yml -e "vm_group=<group>" | grep <group> | wc -l
+ansible-playbook -i dev/inventory list.yml -e "vm_name=<vm-name>"
 
 ansible hosts -i dev/inventory -m shell -a "top -l 1 | head -20"
 ```
@@ -403,8 +402,8 @@ Solution steps:
   1. Delete all VMs (this is required before switching networking modes)  
   
 `ansible-playbook -i dev/inventory delete.yml \ `  
-`-e "vm_group=<all-groups>" \ `  
-`-e "delete_count=<all>"`
+`-e "vm_name=<vm-name>"`  
+_Run this command once for each additional VM, using a unique `vm_name` each time._
 
   2. Verify configuration files  
   
@@ -416,10 +415,10 @@ Solution steps:
   4. Deploy a test VM:  
   
 `ansible-playbook -i dev/inventory deploy.yml \ `  
-`-e "vm_group=test" \ `  
-`-e "desired_vms=1"`
+`-e "vm_name=test-01" \ `  
+`-e "vm_image=<your-image>"`
 
-  5. Verify that the VM received a corporate IP address: `ansible-playbook -i dev/inventory list.yml | grep test`
+  5. Verify that the VM received a corporate IP address: `ansible-playbook -i dev/inventory list.yml -e "vm_name=test-01"`
 
 
 
@@ -563,8 +562,7 @@ Quick diagnostic:
   4. Try pulling the image to a specific host  
   
 `ansible-playbook -i dev/inventory deploy.yml \ `  
-`-e "vm_group=test" \ `  
-`-e "desired_vms=1" \ `  
+`-e "vm_name=test-01" \ `  
 `-e "vm_image=<exact-image-name>" \ `  
 `--limit <specific-host>`
 
@@ -671,9 +669,9 @@ Partial pull failure | Some hosts have corrupted image | Delete and re-pull on a
 
   3. Redeploy VMs from the freshly pulled image  
 `ansible-playbook -i dev/inventory deploy.yml \ `  
-`-e "vm_group=<group>" \ `  
-`-e "desired_vms=<count>" \ `  
-`-e "vm_image=<image>"`
+`-e "vm_name=<vm-name>" \ `  
+`-e "vm_image=<image>"`  
+_Run this command once for each VM to deploy._
 
 
 
@@ -1188,7 +1186,7 @@ Variable name typo or case mismatch | Names don't match exactly (case-sensitive)
 Variable already set with precedence | Playbook has default; your var has lower precedence | Extra vars (`-e`) should override; verify syntax is correct  
 Wrong variable data type | Passing string where an integer expected or vice versa | Check playbook documentation for expected data type; convert if needed  
 Variable not used in playbook | Playbook doesn't reference that variable | Verify playbook supports variable; check playbook source code or docs  
-Syntax error in `-e` flag | Command line parsing failed silently | Use proper quotes: `-e "vm_group=test"` not `-e vm_group=test`  
+Syntax error in `-e` flag | Command line parsing failed silently | Use proper quotes: `-e "vm_name=test"` not `-e vm_name=test`  
 Multiple `-e` flags parsed incorrectly | Only first `-e` being applied | Ensure each `-e` flag is separate and properly formatted  
 Variable scope issue | Variable defined in wrong `group_vars` location | Check variable is in correct inventory group or `all` group  
 Special characters not escaped | Variable value contains spaces or special chars | Quote values properly: `-e "vm_name=test vm"` needs quotes  


### PR DESCRIPTION
## Summary

- Adds a new Android Virtual Devices page covering AVD setup, SDK installation, deploy/manage/delete playbooks, and ADB relay connectivity
- Updates all VDI deployment and operational guide pages to use the current `vm_name`/`vm_image` API, replacing the old group-based `vm_group`/`desired_vms`/`delete_count` variables
- Adds AVD use case to Business Outcomes and AVD validation steps to Validation and Testing
- Removes the "Optional" label from the Semaphore Web UI section in the Deployment Guide

## Pages changed
- `android-virtual-devices.mdx` *(new)*
- `ansible-quick-reference.mdx`
- `business-outcomes-use-cases.mdx`
- `validation-and-testing.mdx`
- `deployment-guide.mdx`
- `ansible-playbook-implementation.mdx`
- `citrix-daas-configuration.mdx`
- `image-management.mdx`
- `production-rollout.mdx`
- `day-2-operations-guide.mdx`
- `troubleshooting-quick-reference.mdx`
- `jamf-enrollment.mdx`