### PR TITLE
fix: restore welcome banner

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -31,6 +31,10 @@
     "suggestEdit": true,
     "raiseIssue": true
   },
+  "banner": {
+    "content": "Welcome to the new MacStadium Documentation site. We've migrated from support.macstadium.com, you're in the right place.",
+    "dismissible": true
+  },
   "integrations": {
     "telemetry": {
       "enabled": true


### PR DESCRIPTION
Restores the welcome banner that was accidentally dropped during a merge conflict resolution on PR #122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)