### PR TITLE
fix: update SEO metadata for Apple Silicon and VNC pages

### DIFF
--- a/iaas/bare-metal-macs/vnc-clients.mdx
+++ b/iaas/bare-metal-macs/vnc-clients.mdx
@@ -1,6 +1,6 @@
 ---
-title: "VNC Clients"
-description: "Compare four free VNC clients for remotely controlling a MacStadium Mac mini server. Covers pros and cons, and Mac-to-Mac vs. cross-platform compatibility."
+title: "Do You Need a VNC Client for Your MacStadium Mac Server?"
+description: "macOS includes built-in VNC server support. Connect to your MacStadium Mac using any VNC client or macOS Screen Sharing, no extra server software needed."
 zendesk_id: 28213326050843
 hidden: true
 ---

--- a/orka/orka-resources/apple-silicon-based-support.mdx
+++ b/orka/orka-resources/apple-silicon-based-support.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Apple Silicon-Based Support"
-description: "Deploy Orka VMs on Apple silicon nodes (M1/M2/M4). Covers arm64 image types, first-deploy caching, features by Orka version, and limits vs. Intel nodes."
+title: "Apple Silicon Mac Servers on Orka: M1, M2, and M4 Node Support"
+description: "Run CI/CD on Apple silicon Mac servers with Orka. Covers M1, M2, and M4 nodes, arm64 images, image caching, and what differs from Intel nodes."
 zendesk_id: 28340672222363
 ---
 


### PR DESCRIPTION
## Summary
- **Apple Silicon page**: title rewritten to target "apple silicon mac servers" search intent (`Apple Silicon Mac Servers on Orka: M1, M2, and M4 Node Support`)
- **VNC Clients page**: title rewritten to match "do I need a VNC client" query phrasing

## Notes
- `mac-mini-comparison-chart.mdx` does not exist in the repo — that task is a no-op
- `do-i-need-a-vnc-server-installed-on-my-mac.mdx` does not exist — updated `vnc-clients.mdx` as closest match (note: this page is currently `hidden: true`)
- No login/sign-in route files exist; login-related pages are all informational docs, none warrant noindex
- The only `/hc/en-us/articles/` link in the codebase points to `support.bitrise.io` (external) — left alone

No body content changed on any file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)