### PR TITLE
fix: replace truncated meta descriptions

### DIFF
--- a/macstadium/legal-and-compliance/copyright-and-trademark-policy.mdx
+++ b/macstadium/legal-and-compliance/copyright-and-trademark-policy.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Copyright and Trademark Policy"
-description: "At MacStadium, we respect the intellectual property rights of others and expect our users to do the same. Our Terms prohibit users from violating someone."
+description: "MacStadium copyright and trademark policy: how to submit DMCA notices, report trademark infringement, and what happens after a report is filed."
 zendesk_id: 42635030589083
 ---
 

--- a/orka/orka-resources/orka-required-url-rules-for-filtering.mdx
+++ b/orka/orka-resources/orka-required-url-rules-for-filtering.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Orka Required URL Rules for Filtering"
-description: "Orka Cluster was designed with minimal internet access to increase security, however, users must set up some restricted internet access. This document."
+description: "Required URL allowlist rules for Orka Cluster. Covers client-side and LAN-side rulesets tested on Cisco Firepower for customers who filter outbound traffic."
 zendesk_id: 39459868610203
 ---
 


### PR DESCRIPTION
Two meta descriptions were Zendesk migration artifacts that cut off mid-sentence:

- `orka-required-url-rules-for-filtering.mdx`: ended with "This document."
- `copyright-and-trademark-policy.mdx`: ended with "violating someone."

Both replaced with complete, accurate descriptions. No body content changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)