### PR TITLE
fix: redirect deleted mac-mini-comparison-chart page to bare-metal-hosts

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1452,7 +1452,7 @@
     },
     {
       "source": "/hc/en-us/articles/28211636270491-Mac-Mini-Comparison-Chart",
-      "destination": "/iaas/bare-metal-macs/mac-mini-comparison-chart",
+      "destination": "/iaas/bare-metal-macs/bare-metal-hosts",
       "permanent": true
     },
     {


### PR DESCRIPTION
## Summary

The `mac-mini-comparison-chart.mdx` page was deleted in a previous cleanup commit but the Zendesk redirect (`/hc/en-us/articles/28211636270491-Mac-Mini-Comparison-Chart`) was never updated — it kept pointing to the deleted URL, causing a 404. GSC was counting this as a failing redirect and ranking a ghost page.

Redirects to `/iaas/bare-metal-macs/bare-metal-hosts` as the closest hardware-focused landing page.

## Test plan

- [x] Verify `/hc/en-us/articles/28211636270491-Mac-Mini-Comparison-Chart` redirects to `/iaas/bare-metal-macs/bare-metal-hosts` in preview
- [ ] Submit for reindexing in GSC after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)