### PR TITLE
Add patch version upgrade section to orka-upgrades doc

### DIFF
--- a/orka/orka-upgrades-and-release-notes/orka-upgrades.mdx
+++ b/orka/orka-upgrades-and-release-notes/orka-upgrades.mdx
@@ -42,19 +42,15 @@ As part of this upgrade, you might need to [download and install](/orka/orka-ove
 | Image cache (Apple silicon nodes) | The image cache is removed from each node. |
 | Namespaces | Your custom namespaces persist. |
 | RoleBindings | Your custom permissions persist. |
-| Kubernetes Pods and services | Your custom Pods and services persist. |  
-  
-### Patch version upgrades
+| Kubernetes Pods and services | Your custom Pods and services persist. |
 
-Orka patch releases (for example, 3.5.0 → 3.5.2) deliver bug fixes and stability improvements between minor releases. Patch upgrades are zero-downtime and have no negative impact on running workloads or VMs.
+#### Patch version upgrades
+
+Orka patch releases (for example, 3.5.0 → 3.5.2) deliver bug fixes and stability improvements between minor releases. Patch upgrades are zero-downtime — no preparation is required, and running VMs and workflows are not interrupted.
 
 <Note>
 **Adding nodes to your cluster requires the latest patch version.** Orka's Ansible image is released on a rolling basis for each major.minor branch, meaning node add operations use the latest available Ansible image for your release line. If your cluster is on an older patch version, node additions will fail. Request a patch upgrade before submitting a node add request.
 </Note>
-
-#### Preparing for the upgrade
-
-No preparation is required for patch upgrades. Running VMs and workflows are not interrupted.
 
 | Aspect | Notes |
 |--------|-------|

--- a/orka/orka-upgrades-and-release-notes/orka-upgrades.mdx
+++ b/orka/orka-upgrades-and-release-notes/orka-upgrades.mdx
@@ -44,6 +44,29 @@ As part of this upgrade, you might need to [download and install](/orka/orka-ove
 | RoleBindings | Your custom permissions persist. |
 | Kubernetes Pods and services | Your custom Pods and services persist. |  
   
+### Patch version upgrades
+
+Orka patch releases (for example, 3.5.0 → 3.5.2) deliver bug fixes and stability improvements between minor releases. Patch upgrades are zero-downtime and have no negative impact on running workloads or VMs.
+
+<Note>
+**Adding nodes to your cluster requires the latest patch version.** Orka's Ansible image is released on a rolling basis for each major.minor branch, meaning node add operations use the latest available Ansible image for your release line. If your cluster is on an older patch version, node additions will fail. Request a patch upgrade before submitting a node add request.
+</Note>
+
+#### Preparing for the upgrade
+
+No preparation is required for patch upgrades. Running VMs and workflows are not interrupted.
+
+| Aspect | Notes |
+|--------|-------|
+| Maintenance window | None required. Patch upgrades are zero-downtime. |
+| Access to the environment | Uninterrupted throughout the upgrade. |
+| Orka users | Persist. |
+| Service Accounts | Persist. Tokens do not need to be regenerated. |
+| VMs and VM configs | Persist. Running VMs are not affected. |
+| Images and ISOs | Persist. |
+| Image cache (Apple silicon nodes) | Persists. |
+| Namespaces and RoleBindings | Persist. |
+
 ### Virtualization and orchestration layer upgrades (Kubernetes, Docker, or Linux)
 
 Occasionally, the Orka team upgrades the components of the virtualization and orchestration layer to a newer version. The version in Orka might run a few versions behind the latest and greatest release to ensure that the virtualization layer and orchestration layer are stable and bug-free.


### PR DESCRIPTION
## Summary

- Adds a new "Patch version upgrades" section to the Orka Upgrades doc, covering what patch upgrades are and when they're needed
- Documents that node additions require the cluster to be on the latest patch version for its major.minor release branch — previously undocumented, surfaced only as a support escalation when node add workflows failed
- Clarifies that patch upgrades are zero-downtime with no impact on running VMs or workloads

## Context

Node add failures on clusters running older patch versions (e.g., 3.5.0 vs. 3.5.2) have come up in support multiple times. This documentation adds context for customers.

## Test plan

- [ ] Verify the new section renders correctly in the Mintlify preview
- [ ] Confirm the `<Note>` callout about node additions is visible and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)