### PR TITLE
Add Upgrade Guides nav group, separate from Release Notes

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -273,6 +273,13 @@
             ]
           },
           {
+            "group": "Upgrade Guides",
+            "pages": [
+              "orka/orka-upgrades-and-release-notes/orka-upgrades",
+              "orka/orka-upgrades-and-release-notes/kubernetes-upgrade-guide"
+            ]
+          },
+          {
             "group": "Release Notes",
             "pages": [
               "orka/orka-upgrades-and-release-notes/orka-35-release-notes",
@@ -280,8 +287,7 @@
               "orka/orka-upgrades-and-release-notes/orka-33-release-notes",
               "orka/orka-upgrades-and-release-notes/orka-32-release-notes",
               "orka/orka-upgrades-and-release-notes/orka-31-release-notes",
-              "orka/orka-upgrades-and-release-notes/orka-30-release-notes",
-              "orka/orka-upgrades-and-release-notes/orka-upgrades"
+              "orka/orka-upgrades-and-release-notes/orka-30-release-notes"
             ]
           }
         ]


### PR DESCRIPTION
## Summary

- Adds a new "Upgrade Guides" navigation group containing `orka-upgrades` and the upcoming `kubernetes-upgrade-guide`
- Removes the upgrade how-to from the "Release Notes" group, which now contains only version-specific release notes
- No content changes — nav restructure only

## Test plan

- [ ] Verify "Upgrade Guides" group appears in the nav above "Release Notes"
- [ ] Verify `orka-upgrades` page still resolves correctly
- [ ] Verify "Release Notes" group contains only version release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)