### PR TITLE
Steer users from NFS to Harbor OCI for image storage

### DIFF
--- a/orka/orka-devops-integrations/base-images.mdx
+++ b/orka/orka-devops-integrations/base-images.mdx
@@ -4,6 +4,10 @@ description: "List, pull, generate, upload, and update Orka base images. Covers 
 zendesk_id: 28332123227803
 ---
 
+<Note>
+This page covers base image workflows using the legacy `orka` CLI (Orka 2.x). If you are on Orka 3.x, the recommended image storage path is OCI via Harbor. See [Using Harbor OCI Storage with the Orka CLI](/orka/oci-images/using-harbor-oci-storage-with-the-orka-cli) and [Migrating NFS Images to OCI with Harbor](/orka/oci-images/orka-self-service-migrating-nfs-images-to-oci-with-harbor).
+</Note>
+
 How to list, pull, generate, upload, and update base images with the Orka CLI.  
   
 This page discusses base image workflows in the Orka CLI. For more information about workflows with the Orka API, see [Orka API Reference: Images](https://documenter.getpostman.com/view/6574930/S1ETRGzt?version=latest#c311a394-6be6-4e8c-8b9b-b7185df6563e).

--- a/orka/orka-devops-integrations/base-images.mdx
+++ b/orka/orka-devops-integrations/base-images.mdx
@@ -5,7 +5,7 @@ zendesk_id: 28332123227803
 ---
 
 <Note>
-This page covers base image workflows using the legacy `orka` CLI (Orka 2.x). If you are on Orka 3.x, the recommended image storage path is OCI via Harbor. See [Using Harbor OCI Storage with the Orka CLI](/orka/oci-images/using-harbor-oci-storage-with-the-orka-cli) and [Migrating NFS Images to OCI with Harbor](/orka/oci-images/orka-self-service-migrating-nfs-images-to-oci-with-harbor).
+This page covers base image workflows using the legacy `orka` CLI (Orka 2.x). If you are on Orka 3.5 or later, the recommended image storage path is OCI via Harbor. See [Using Harbor OCI Storage with the Orka CLI](/orka/oci-images/using-harbor-oci-storage-with-the-orka-cli) and [Migrating NFS Images to OCI with Harbor](/orka/oci-images/orka-self-service-migrating-nfs-images-to-oci-with-harbor).
 </Note>
 
 How to list, pull, generate, upload, and update base images with the Orka CLI.  

--- a/orka/orka-resources/image-caching.mdx
+++ b/orka/orka-resources/image-caching.mdx
@@ -10,7 +10,7 @@ zendesk_id: 30115530131355
 
 # About
 
-Orka 3.2 introduces Image Caching. This feature lets you download Orka images ahead of time to any node in the Orka cluster if you have admin privileges. Pre-caching images provides faster and more reliable VM deployments by reducing delays caused by network bandwidth issues. Without Image Caching, automated CI jobs pull new images from the local cluster datastore (NFS mount) or a remote registry during CI runtime, which can cause delays.
+Orka 3.2 introduces Image Caching. This feature lets you download Orka images ahead of time to any node in the Orka cluster if you have admin privileges. Pre-caching images provides faster and more reliable VM deployments by reducing delays caused by network bandwidth issues. Without Image Caching, automated CI jobs pull new images from a remote OCI registry or the local cluster datastore (NFS) during CI runtime, which can cause delays.
 
 # System Requirements
 
@@ -30,17 +30,17 @@ The cluster knows which nodes have necessary images cached, greatly reducing ima
 
 ## Key Concepts
 
-  * Image Caching allows preemptive copying of an Orka VM image on any cluster node member, to avoid delays caused by network bandwidth when images are pulled from the cluster NFS mount or from a public registry cloud service.
+  * Image Caching allows preemptive copying of an Orka VM image on any cluster node member, to avoid delays caused by network bandwidth when images are pulled from an OCI registry or the cluster NFS datastore.
   * An image is the bits on disk representing a VM that can be used for saving state and sharing modifications.
   * MacStadium base VM Orka images are macOS OCI compliant VM images stored in our public GitHub registry [ghcr.io/macstadium/orka-images/](https://ghcr.io/macstadium/orka-images/) with user credentials user/pwd: **admin/admin** , have Homebrew package manager installed, orka-vm-tools installed, and have screen sharing enabled and SSH access enabled.
-  * Cluster local storage is an NFS mounted filesystem for storing images locally (local registry service).
+  * Cluster local storage is an NFS mounted filesystem for storing images locally (local registry service). NFS is a legacy storage path. For new clusters, OCI-based storage via Harbor is recommended. See [Migrating NFS images to OCI with Harbor](/orka/oci-images/orka-self-service-migrating-nfs-images-to-oci-with-harbor).
   * A VM is a virtual runtime on top of the macOS host. The VM runs a guest OS image and macOS supports up to 2 running VMs per cluster node.
   * Sequoia refers to macOS 15 (the latest Sequoia release available from Apple’s servers). macOS 26 Tahoe is also available as a guest OS starting in Orka 3.5.
 
 
 
 <Note>
-Orka Cluster 3.0 and later can deploy a VM from multiple image sources: a cloud image datastore (OCI registry service), Orka’s local cluster registry (Cluster NFS mount), and lastly cached images on a cluster node member. Now in Orka 3.2 release there are three distinct CLI commands to display each type of storage and the images available on that specific datastore.
+Orka Cluster 3.0 and later can deploy a VM from multiple image sources: a cloud image datastore (OCI registry service), cached images on a cluster node member, and Orka’s local cluster registry (NFS, legacy). Now in Orka 3.2 release there are three distinct CLI commands to display each type of storage and the images available on that specific datastore.
 </Note>
 
 # Getting Started
@@ -49,7 +49,7 @@ After the cluster nodes are upgraded to version 3.2, you can access the new Imag
 
   1. Run `orka3 imagecache -h` to see the CLI tree structure: commands, subcommands and options/flags
   2. Run `orka3 remote-image list` to view Orka VM images available on MacStadium's public registry (ghcr.io/macstadium/orka-images/)
-  3. Run `orka3 image list` to view images already downloaded to the cluster local registry (cluster NFS mount)
+  3. Run `orka3 image list` to view images already downloaded to the cluster local registry (NFS, legacy)
   4. Run `orka3 imagecache list` to view images currently stored on Orka Cluster nodes
   5. View the Orka Cluster node names by typing `orka3 node list`
   6. Add a new image to a cluster node `orka3 imagecache add`

--- a/orka/orka-resources/image-caching.mdx
+++ b/orka/orka-resources/image-caching.mdx
@@ -33,7 +33,7 @@ The cluster knows which nodes have necessary images cached, greatly reducing ima
   * Image Caching allows preemptive copying of an Orka VM image on any cluster node member, to avoid delays caused by network bandwidth when images are pulled from an OCI registry or the cluster NFS datastore.
   * An image is the bits on disk representing a VM that can be used for saving state and sharing modifications.
   * MacStadium base VM Orka images are macOS OCI compliant VM images stored in our public GitHub registry [ghcr.io/macstadium/orka-images/](https://ghcr.io/macstadium/orka-images/) with user credentials user/pwd: **admin/admin** , have Homebrew package manager installed, orka-vm-tools installed, and have screen sharing enabled and SSH access enabled.
-  * Cluster local storage is an NFS mounted filesystem for storing images locally (local registry service). NFS is a legacy storage path. For new clusters, OCI-based storage via Harbor is recommended. See [Migrating NFS images to OCI with Harbor](/orka/oci-images/orka-self-service-migrating-nfs-images-to-oci-with-harbor).
+  * Cluster local storage is an NFS mounted filesystem for storing images locally (local registry service). NFS is a legacy storage path. For clusters on Orka 3.5 or later, OCI-based storage via Harbor is recommended. See [Migrating NFS images to OCI with Harbor](/orka/oci-images/orka-self-service-migrating-nfs-images-to-oci-with-harbor).
   * A VM is a virtual runtime on top of the macOS host. The VM runs a guest OS image and macOS supports up to 2 running VMs per cluster node.
   * Sequoia refers to macOS 15 (the latest Sequoia release available from Apple’s servers). macOS 26 Tahoe is also available as a guest OS starting in Orka 3.5.
 

--- a/orka/quick-start-guides/orka3-cli-quick-start.mdx
+++ b/orka/quick-start-guides/orka3-cli-quick-start.mdx
@@ -18,7 +18,7 @@ If you want to skip the detailed explanations, just run through these steps on y
   10. `orka3 vm list <VM_NAME>` and `orka3 vm list <VM_NAME> -o wide`
   11. Run Apple Screen Sharing to connect to the VM instance. Use `vnc://<VM-IP>:<Screenshare-port>` with the IP and port from Step 7. Use the `admin/admin` credentials.
   12. On the VM, change the login credentials, apply the latest OS updates, and install (or upgrade) the Orka VM Tools for added security and functionality.
-  13. `orka3 vm commit <VM_NAME>` or `orka3 vm save <VM_NAME>`
+  13. `orka3 vm push <VM_NAME> <IMAGE:TAG>` (Apple Silicon, recommended) or `orka3 vm commit <VM_NAME>` / `orka3 vm save <VM_NAME>` (writes to NFS local storage)
   14. `orka3 vm deploy --image <IMAGE_NAME> -y` (use the name of the newly saved image or the original image, if you committed the changes to it).
   15. Run Apple Screen Sharing and connect to the newly deployed VM. Use the connection information printed by `orka3 vm deploy`. Verify that your changes are there.
   16. `orka3 vm delete -v <NAME>`
@@ -255,7 +255,11 @@ If your cluster and CLI are not running the latest Orka version, download and in
 
 Changing a running VM's configuration or file system does not affect its base image. As soon as you delete the VM, your changes will be lost, and you will need to recreate them manually on other VMs.
 
-To create changes that stick and appear on future deployments, you can commit your changes to the base image, save the changes as a new image, or push your changes to an OCI-compatible registry.
+To create changes that stick and appear on future deployments, you can push your changes to an OCI-compatible registry, commit your changes to the base image, or save the changes as a new image.
+
+<Note>
+For Apple Silicon clusters, **pushing to an OCI registry** (such as Harbor, available within your cluster) is the recommended approach. `vm commit` and `vm save` write to NFS local cluster storage, which is being phased out in favor of OCI. See [Using Harbor OCI Storage with the Orka CLI](/orka/oci-images/using-harbor-oci-storage-with-the-orka-cli).
+</Note>
 
 > #### **Glossary: Commit changes**
 > 

--- a/orka/quick-start-guides/orka3-cli-quick-start.mdx
+++ b/orka/quick-start-guides/orka3-cli-quick-start.mdx
@@ -258,7 +258,7 @@ Changing a running VM's configuration or file system does not affect its base im
 To create changes that stick and appear on future deployments, you can push your changes to an OCI-compatible registry, commit your changes to the base image, or save the changes as a new image.
 
 <Note>
-For Apple Silicon clusters, **pushing to an OCI registry** (such as Harbor, available within your cluster) is the recommended approach. `vm commit` and `vm save` write to NFS local cluster storage, which is being phased out in favor of OCI. See [Using Harbor OCI Storage with the Orka CLI](/orka/oci-images/using-harbor-oci-storage-with-the-orka-cli).
+On Orka 3.5 or later, **pushing to an OCI registry** (such as Harbor, available within your cluster) is the recommended approach for Apple Silicon clusters. `vm commit` and `vm save` write to NFS local cluster storage, which is being phased out in favor of OCI. See [Using Harbor OCI Storage with the Orka CLI](/orka/oci-images/using-harbor-oci-storage-with-the-orka-cli).
 </Note>
 
 > #### **Glossary: Commit changes**


### PR DESCRIPTION
## Summary

- `image-caching.mdx`: Position OCI first throughout; label NFS as legacy in Key Concepts with link to the migration guide; update Note block to list OCI before NFS
- `orka3-cli-quick-start.mdx`: Update step 13 in quick reference to list `vm push` as recommended; add Note callout at top of section 7 pointing Apple Silicon users to Harbor OCI
- `base-images.mdx`: Add Note at top redirecting Orka 3.x users to Harbor OCI workflow pages (this page uses legacy `orka` 2.x commands)

## Context

Multiple customers have hit NFS storage limits causing cluster-halting incidents. NFS is being phased out in favor of OCI/Harbor. These changes ensure new users land on the right path from the start rather than defaulting to NFS workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)